### PR TITLE
Replace widget test with login text verification

### DIFF
--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -1,30 +1,15 @@
-// This is a basic Flutter widget test.
-//
-// To perform an interaction with a widget in your test, use the WidgetTester
-// utility in the flutter_test package. For example, you can send tap and scroll
-// gestures. You can also use WidgetTester to find child widgets in the widget
-// tree, read text, and verify that the values of widget properties are correct.
-
-import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:meysshop_front1/main.dart';
 
 void main() {
-  testWidgets('Counter increments smoke test', (WidgetTester tester) async {
-    // Build our app and trigger a frame.
+  testWidgets('Login screen shows welcome texts', (WidgetTester tester) async {
     await tester.pumpWidget(const MyApp());
+    await tester.pumpAndSettle();
 
-    // Verify that our counter starts at 0.
-    expect(find.text('0'), findsOneWidget);
-    expect(find.text('1'), findsNothing);
-
-    // Tap the '+' icon and trigger a frame.
-    await tester.tap(find.byIcon(Icons.add));
-    await tester.pump();
-
-    // Verify that our counter has incremented.
-    expect(find.text('0'), findsNothing);
-    expect(find.text('1'), findsOneWidget);
+    expect(find.text('Bienvenido a Meysshop'), findsOneWidget);
+    expect(find.text('Inicia sesión para continuar'), findsOneWidget);
+    expect(find.text('¿Olvidaste tu contraseña?'), findsOneWidget);
+    expect(find.text('Iniciar sesión'), findsOneWidget);
   });
 }


### PR DESCRIPTION
## Summary
- replace the default counter widget test with one that pumps `MyApp` and asserts the login screen texts

## Testing
- `flutter test` *(fails locally: `flutter` command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cbce1d37f8832fb849b177d3ffc256