### PR TITLE
Add JSON serialization for models and implement API repositories

### DIFF
--- a/lib/models/order.dart
+++ b/lib/models/order.dart
@@ -24,6 +24,77 @@ class Order {
 
   double get total => items.fold(0, (sum, it) => sum + it.subtotal);
 
+  factory Order.fromJson(Map<String, dynamic> json) {
+    DateTime _readDate(dynamic value) {
+      if (value is DateTime) return value;
+      if (value is String) {
+        try {
+          return DateTime.parse(value);
+        } catch (_) {
+          return DateTime.now();
+        }
+      }
+      if (value is int) {
+        // Asumimos milisegundos
+        return DateTime.fromMillisecondsSinceEpoch(value);
+      }
+      return DateTime.now();
+    }
+
+    List<OrderItem> _readItems(dynamic value) {
+      if (value is List) {
+        return value
+            .whereType<Map<String, dynamic>>()
+            .map(OrderItem.fromJson)
+            .toList(growable: false);
+      }
+      return const <OrderItem>[];
+    }
+
+    String _readString(dynamic value, {String fallback = ''}) {
+      if (value is String) return value;
+      if (value == null) return fallback;
+      return value.toString();
+    }
+
+    final id = _readString(json['id']);
+    if (id.isEmpty) {
+      throw const FormatException('Order JSON sin "id"');
+    }
+
+    final customerId = _readString(json['customerId'] ?? json['clienteId'] ?? json['userId']);
+    if (customerId.isEmpty) {
+      throw const FormatException('Order JSON sin "customerId"');
+    }
+
+    final customerName = _readString(json['customerName'] ?? json['clienteNombre'] ?? json['nombreCliente']);
+    final customerEmail = _readString(json['customerEmail'] ?? json['clienteEmail']);
+
+    return Order(
+      id: id,
+      customerId: customerId,
+      customerName: customerName,
+      customerEmail: customerEmail,
+      createdAt: _readDate(json['createdAt'] ?? json['fecha'] ?? json['created_at']),
+      status: orderStatusFromApiValue(_readString(json['status'] ?? json['estado'], fallback: 'pending')),
+      items: _readItems(json['items'] ?? json['detalle'] ?? json['products']),
+      notes: (json['notes'] ?? json['notas'] ?? json['comentarios']) as String?,
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'id': id,
+      'customerId': customerId,
+      'customerName': customerName,
+      'customerEmail': customerEmail,
+      'createdAt': createdAt.toIso8601String(),
+      'status': status.apiValue,
+      'items': items.map((it) => it.toJson()).toList(),
+      if (notes != null) 'notes': notes,
+    };
+  }
+
   Order copyWith({
     String? id,
     String? customerId,

--- a/lib/models/order_item.dart
+++ b/lib/models/order_item.dart
@@ -10,4 +10,29 @@ class OrderItem {
   });
 
   double get subtotal => productSnapshot.price * qty;
+
+  factory OrderItem.fromJson(Map<String, dynamic> json) {
+    final productJson = json['productSnapshot'] ?? json['product'] ?? json['producto'];
+    if (productJson is! Map<String, dynamic>) {
+      throw const FormatException('OrderItem JSON sin producto');
+    }
+
+    int _readQty(dynamic value) {
+      if (value is num) return value.toInt();
+      if (value is String) return int.tryParse(value) ?? 0;
+      return 0;
+    }
+
+    return OrderItem(
+      productSnapshot: Product.fromJson(productJson),
+      qty: _readQty(json['qty'] ?? json['cantidad'] ?? json['quantity']),
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'productSnapshot': productSnapshot.toJson(),
+      'qty': qty,
+    };
+  }
 }

--- a/lib/models/order_status.dart
+++ b/lib/models/order_status.dart
@@ -26,4 +26,31 @@ extension OrderStatusX on OrderStatus {
       case OrderStatus.cancelled: return 4;
     }
   }
+
+  String get apiValue => name;
+}
+
+OrderStatus orderStatusFromApiValue(String? value) {
+  if (value == null) return OrderStatus.pending;
+  final normalized = value.toLowerCase();
+  switch (normalized) {
+    case 'pending':
+    case 'pendiente':
+      return OrderStatus.pending;
+    case 'preparing':
+    case 'preparando':
+      return OrderStatus.preparing;
+    case 'shipped':
+    case 'enviado':
+      return OrderStatus.shipped;
+    case 'completed':
+    case 'completado':
+      return OrderStatus.completed;
+    case 'cancelled':
+    case 'canceled':
+    case 'cancelado':
+      return OrderStatus.cancelled;
+    default:
+      return OrderStatus.pending;
+  }
 }

--- a/lib/models/product.dart
+++ b/lib/models/product.dart
@@ -1,4 +1,5 @@
 class Product {
+  final String? id;
   final String name;
   final double price;
   final String imageUrl;
@@ -6,6 +7,7 @@ class Product {
   final String estado;
 
   const Product({
+    this.id,
     required this.name,
     required this.price,
     required this.imageUrl,
@@ -13,7 +15,58 @@ class Product {
     required this.estado,
   });
 
+  factory Product.fromJson(Map<String, dynamic> json) {
+    double _readDouble(dynamic value) {
+      if (value is num) return value.toDouble();
+      if (value is String) {
+        return double.tryParse(value) ?? 0.0;
+      }
+      return 0.0;
+    }
+
+    int _readInt(dynamic value) {
+      if (value is num) return value.toInt();
+      if (value is String) return int.tryParse(value) ?? 0;
+      return 0;
+    }
+
+    String _readString(dynamic value, {String fallback = ''}) {
+      if (value is String) return value;
+      if (value == null) return fallback;
+      return value.toString();
+    }
+
+    final name = _readString(json['name'] ?? json['nombre'], fallback: '');
+    if (name.isEmpty) {
+      throw const FormatException('Product JSON sin "name"');
+    }
+
+    return Product(
+      id: json['id']?.toString(),
+      name: name,
+      price: _readDouble(json['price'] ?? json['precio']),
+      imageUrl: _readString(
+        json['imageUrl'] ?? json['imagenUrl'] ?? json['image_url'] ?? json['imagen'],
+        fallback: '',
+      ),
+      cantidad: _readInt(json['cantidad'] ?? json['stock']),
+      estado: _readString(json['estado'] ?? json['status'] ?? json['estadoProducto'], fallback: 'Activo'),
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      if (id != null) 'id': id,
+      'name': name,
+      'price': price,
+      'imageUrl': imageUrl,
+      'cantidad': cantidad,
+      'estado': estado,
+    };
+  }
+
   Product copyWith({
+    String? id,
     String? name,
     double? price,
     String? imageUrl,
@@ -21,6 +74,7 @@ class Product {
     String? estado,
   }) {
     return Product(
+      id: id ?? this.id,
       name: name ?? this.name,
       price: price ?? this.price,
       imageUrl: imageUrl ?? this.imageUrl,

--- a/lib/models/usuario.dart
+++ b/lib/models/usuario.dart
@@ -15,6 +15,49 @@ class Usuario {
     this.avatarUrl,
   });
 
+  factory Usuario.fromJson(Map<String, dynamic> json) {
+    final dynamic rawId = json['id'] ?? json['userId'];
+    if (rawId == null) {
+      throw const FormatException('Usuario JSON sin "id"');
+    }
+
+    String _readString(dynamic value, {String fallback = ''}) {
+      if (value is String) return value;
+      if (value == null) return fallback;
+      return value.toString();
+    }
+
+    final id = _readString(rawId);
+    final nombre = _readString(json['nombre'] ?? json['name'], fallback: '');
+    final email = _readString(json['email'], fallback: '');
+    if (nombre.isEmpty) {
+      throw const FormatException('Usuario JSON sin "nombre"');
+    }
+    if (email.isEmpty) {
+      throw const FormatException('Usuario JSON sin "email"');
+    }
+
+    return Usuario(
+      id: id,
+      nombre: nombre,
+      email: email,
+      rol: _readString(json['rol'] ?? json['role'], fallback: 'cliente'),
+      phone: (json['phone'] ?? json['telefono'] ?? json['phoneNumber']) as String?,
+      avatarUrl: (json['avatarUrl'] ?? json['avatar_url'] ?? json['avatar']) as String?,
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'id': id,
+      'nombre': nombre,
+      'email': email,
+      'rol': rol,
+      if (phone != null) 'phone': phone,
+      if (avatarUrl != null) 'avatarUrl': avatarUrl,
+    };
+  }
+
   Usuario copyWith({
     String? id,
     String? nombre,

--- a/lib/screens/edit_product_screen.dart
+++ b/lib/screens/edit_product_screen.dart
@@ -38,6 +38,7 @@ class _EditProductScreenState extends State<EditProductScreen> {
     if (!_formKey.currentState!.validate()) return;
 
     final updated = Product(
+      id: widget.product.id,
       name: _nameController.text.trim(),
       price: double.parse(_priceController.text.trim()),
       imageUrl: _imageController.text.trim(),

--- a/lib/screens/main_screen.dart
+++ b/lib/screens/main_screen.dart
@@ -99,16 +99,23 @@ class _MainScreenState extends State<MainScreen> {
 
   // ---------- Helpers de stock / carrito ----------
 
+  bool _sameProduct(Product a, Product b) {
+    if (a.id != null && b.id != null) {
+      return a.id == b.id;
+    }
+    return a.name.toLowerCase() == b.name.toLowerCase();
+  }
+
   int _availableStockOf(Product product) {
-    final match = _products.where((p) => p.name == product.name);
+    final match = _products.where((p) => _sameProduct(p, product));
     if (match.isNotEmpty) return match.first.cantidad;
     return product.cantidad;
   }
 
   int _qtyInCartOf(Product product) {
-    final idx = _cart.indexWhere((it) => it.product.name == product.name);
+    final idx = _cart.indexWhere((it) => _sameProduct(it.product, product));
     return idx >= 0 ? _cart[idx].qty : 0;
-    }
+  }
 
   void _addToCart(Product product, int qty) {
     if (isAdminEffective) return; // admin no compra
@@ -132,7 +139,7 @@ class _MainScreenState extends State<MainScreen> {
       return;
     }
 
-    final idx = _cart.indexWhere((it) => it.product.name == product.name);
+    final idx = _cart.indexWhere((it) => _sameProduct(it.product, product));
     setState(() {
       if (idx >= 0) {
         _cart[idx] = _cart[idx].copyWith(qty: _cart[idx].qty + safeQty);

--- a/lib/services/api_client.dart
+++ b/lib/services/api_client.dart
@@ -1,1 +1,176 @@
-class ApiClient {}
+import 'dart:convert';
+
+import 'package:http/http.dart' as http;
+
+class ApiClient {
+  ApiClient({
+    required String baseUrl,
+    http.Client? httpClient,
+  })  : _baseUri = _normalizeBase(baseUrl),
+        _http = httpClient ?? http.Client();
+
+  final Uri _baseUri;
+  final http.Client _http;
+
+  static Uri _normalizeBase(String baseUrl) {
+    final uri = Uri.parse(baseUrl);
+    if (uri.path.isEmpty || uri.path == '/') {
+      return uri.replace(path: '');
+    }
+    return uri;
+  }
+
+  Uri _resolve(String path, [Map<String, dynamic>? queryParameters]) {
+    final normalizedPath = path.startsWith('/') ? path.substring(1) : path;
+    final uri = _baseUri.resolve(normalizedPath);
+    if (queryParameters == null || queryParameters.isEmpty) {
+      return uri;
+    }
+    final qp = <String, String>{};
+    queryParameters.forEach((key, value) {
+      if (value == null) return;
+      qp[key] = value.toString();
+    });
+    return uri.replace(queryParameters: qp);
+  }
+
+  Map<String, String> _mergeHeaders(Map<String, String>? headers) {
+    final base = <String, String>{
+      'Accept': 'application/json',
+      'Content-Type': 'application/json',
+    };
+    if (headers != null) {
+      base.addAll(headers);
+    }
+    return base;
+  }
+
+  dynamic _decodeBody(http.Response response) {
+    if (response.bodyBytes.isEmpty) {
+      return null;
+    }
+    final text = utf8.decode(response.bodyBytes);
+    if (text.isEmpty) return null;
+    return jsonDecode(text);
+  }
+
+  Never _throwError(http.Response response) {
+    throw ApiException(
+      statusCode: response.statusCode,
+      message: response.reasonPhrase ?? 'Error HTTP',
+      responseBody: response.body.isEmpty ? null : response.body,
+    );
+  }
+
+  Future<dynamic> get(
+    String path, {
+    Map<String, dynamic>? queryParameters,
+    Map<String, String>? headers,
+  }) async {
+    final response = await _http.get(
+      _resolve(path, queryParameters),
+      headers: _mergeHeaders(headers),
+    );
+    if (response.statusCode < 200 || response.statusCode >= 300) {
+      _throwError(response);
+    }
+    return _decodeBody(response);
+  }
+
+  Future<dynamic> post(
+    String path, {
+    Object? body,
+    Map<String, dynamic>? queryParameters,
+    Map<String, String>? headers,
+  }) async {
+    final response = await _http.post(
+      _resolve(path, queryParameters),
+      headers: _mergeHeaders(headers),
+      body: _encodeBody(body),
+    );
+    if (response.statusCode < 200 || response.statusCode >= 300) {
+      _throwError(response);
+    }
+    return _decodeBody(response);
+  }
+
+  Future<dynamic> put(
+    String path, {
+    Object? body,
+    Map<String, dynamic>? queryParameters,
+    Map<String, String>? headers,
+  }) async {
+    final response = await _http.put(
+      _resolve(path, queryParameters),
+      headers: _mergeHeaders(headers),
+      body: _encodeBody(body),
+    );
+    if (response.statusCode < 200 || response.statusCode >= 300) {
+      _throwError(response);
+    }
+    return _decodeBody(response);
+  }
+
+  Future<dynamic> patch(
+    String path, {
+    Object? body,
+    Map<String, dynamic>? queryParameters,
+    Map<String, String>? headers,
+  }) async {
+    final response = await _http.patch(
+      _resolve(path, queryParameters),
+      headers: _mergeHeaders(headers),
+      body: _encodeBody(body),
+    );
+    if (response.statusCode < 200 || response.statusCode >= 300) {
+      _throwError(response);
+    }
+    return _decodeBody(response);
+  }
+
+  Future<void> delete(
+    String path, {
+    Object? body,
+    Map<String, dynamic>? queryParameters,
+    Map<String, String>? headers,
+  }) async {
+    final response = await _http.delete(
+      _resolve(path, queryParameters),
+      headers: _mergeHeaders(headers),
+      body: _encodeBody(body),
+    );
+    if (response.statusCode < 200 || response.statusCode >= 300) {
+      _throwError(response);
+    }
+  }
+
+  void close() => _http.close();
+
+  String? _encodeBody(Object? body) {
+    if (body == null) return null;
+    if (body is String) return body;
+    return jsonEncode(body);
+  }
+}
+
+class ApiException implements Exception {
+  ApiException({
+    required this.statusCode,
+    required this.message,
+    this.responseBody,
+  });
+
+  final int statusCode;
+  final String message;
+  final String? responseBody;
+
+  @override
+  String toString() {
+    final buffer = StringBuffer('ApiException($statusCode): $message');
+    if (responseBody != null && responseBody!.isNotEmpty) {
+      buffer.write(' -> ');
+      buffer.write(responseBody);
+    }
+    return buffer.toString();
+  }
+}

--- a/lib/services/order_repo_api.dart
+++ b/lib/services/order_repo_api.dart
@@ -1,1 +1,50 @@
-// ApiOrderRepository implementation
+import '../models/order.dart';
+import '../models/order_status.dart';
+import 'api_client.dart';
+import 'order_repository.dart';
+
+class ApiOrderRepository implements OrderRepository {
+  ApiOrderRepository(this._client);
+
+  final ApiClient _client;
+  static const String _basePath = '/api/pedidos';
+
+  @override
+  Future<List<Order>> fetchOrders({String? q, OrderStatus? status}) async {
+    final query = <String, dynamic>{};
+    if (q != null && q.trim().isNotEmpty) {
+      query['q'] = q.trim();
+    }
+    if (status != null) {
+      query['status'] = status.apiValue;
+    }
+    final data = await _client.get(
+      _basePath,
+      queryParameters: query.isEmpty ? null : query,
+    );
+    if (data is List) {
+      return data
+          .whereType<Map<String, dynamic>>()
+          .map(Order.fromJson)
+          .toList(growable: false);
+    }
+    throw const FormatException('Respuesta inesperada al listar pedidos');
+  }
+
+  @override
+  Future<void> updateStatus(String orderId, OrderStatus newStatus) async {
+    await _client.patch(
+      '$_basePath/${Uri.encodeComponent(orderId)}/status',
+      body: {'status': newStatus.apiValue},
+    );
+  }
+
+  @override
+  Future<Order> createOrder(Order o) async {
+    final data = await _client.post(_basePath, body: o.toJson());
+    if (data is Map<String, dynamic>) {
+      return Order.fromJson(data);
+    }
+    throw const FormatException('Respuesta inesperada al crear pedido');
+  }
+}

--- a/lib/services/product_repo_api.dart
+++ b/lib/services/product_repo_api.dart
@@ -1,1 +1,60 @@
-// ApiProductRepository implementation
+import '../models/product.dart';
+import 'api_client.dart';
+import 'product_repository.dart';
+
+class ApiProductRepository implements ProductRepository {
+  ApiProductRepository(this._client);
+
+  final ApiClient _client;
+  static const String _basePath = '/api/productos';
+
+  @override
+  Future<List<Product>> fetchProducts({String? search}) async {
+    final query = <String, dynamic>{};
+    if (search != null && search.trim().isNotEmpty) {
+      query['q'] = search.trim();
+    }
+    final data = await _client.get(
+      _basePath,
+      queryParameters: query.isEmpty ? null : query,
+    );
+    if (data is List) {
+      return data
+          .whereType<Map<String, dynamic>>()
+          .map(Product.fromJson)
+          .toList(growable: false);
+    }
+    throw const FormatException('Respuesta inesperada al listar productos');
+  }
+
+  @override
+  Future<Product> createProduct(Product p) async {
+    final payload = p.toJson();
+    final data = await _client.post(_basePath, body: payload);
+    if (data is Map<String, dynamic>) {
+      return Product.fromJson(data);
+    }
+    throw const FormatException('Respuesta inesperada al crear producto');
+  }
+
+  @override
+  Future<Product> updateProduct(Product p) async {
+    final id = p.id;
+    if (id == null || id.isEmpty) {
+      throw const ArgumentError('El producto debe tener un id para actualizarse');
+    }
+    final data = await _client.put(
+      '$_basePath/${Uri.encodeComponent(id)}',
+      body: p.toJson(),
+    );
+    if (data is Map<String, dynamic>) {
+      return Product.fromJson(data);
+    }
+    throw const FormatException('Respuesta inesperada al actualizar producto');
+  }
+
+  @override
+  Future<void> deleteProduct(String productId) async {
+    await _client.delete('$_basePath/${Uri.encodeComponent(productId)}');
+  }
+}

--- a/lib/services/profile_repo_api.dart
+++ b/lib/services/profile_repo_api.dart
@@ -1,1 +1,28 @@
-// ApiProfileRepository implementation
+import '../models/usuario.dart';
+import 'api_client.dart';
+import 'profile_repository.dart';
+
+class ApiProfileRepository implements ProfileRepository {
+  ApiProfileRepository(this._client);
+
+  final ApiClient _client;
+  static const String _mePath = '/api/me';
+
+  @override
+  Future<Usuario> getMe() async {
+    final data = await _client.get(_mePath);
+    if (data is Map<String, dynamic>) {
+      return Usuario.fromJson(data);
+    }
+    throw const FormatException('Respuesta inesperada al obtener el perfil');
+  }
+
+  @override
+  Future<Usuario> updateMe(Usuario u) async {
+    final data = await _client.put(_mePath, body: u.toJson());
+    if (data is Map<String, dynamic>) {
+      return Usuario.fromJson(data);
+    }
+    throw const FormatException('Respuesta inesperada al actualizar el perfil');
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -38,6 +38,7 @@ dependencies:
   path_provider: ^2.1.3
   share_plus: ^10.0.0
   fl_chart: ^0.69.0
+  http: ^1.2.2
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- add fromJson/toJson helpers to Usuario, Product, Order and OrderItem while wiring status parsing utilities
- introduce an HTTP ApiClient plus API repositories that materialize responses via the new model factories
- propagate optional product ids through the dummy repo and UI so edits preserve identifiers, and add the http dependency

## Testing
- `dart format lib pubspec.yaml` *(fails: dart command is unavailable in the environment)*
- `flutter format lib pubspec.yaml` *(fails: flutter command is unavailable in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cbce11df04832fa816e67153e4fade