### PR TITLE
Refactor API product repository to use cached ID handling

### DIFF
--- a/lib/services/product_repo_api.dart
+++ b/lib/services/product_repo_api.dart
@@ -2,7 +2,6 @@ import '../models/product.dart';
 import 'api_client.dart';
 import 'product_repository.dart';
 
-
 /// Implementación que consume la API REST (por ahora /api/clientes).
 class ApiProductRepository implements ProductRepository {
   ApiProductRepository(
@@ -15,13 +14,6 @@ class ApiProductRepository implements ProductRepository {
 
   final Map<String, String> _idByCacheKey = {};
 
-class ApiProductRepository implements ProductRepository {
-  ApiProductRepository(this._client);
-
-  final ApiClient _client;
-  static const String _basePath = '/api/productos';
-
-
   @override
   Future<List<Product>> fetchProducts({String? search}) async {
     final query = <String, dynamic>{};
@@ -29,10 +21,16 @@ class ApiProductRepository implements ProductRepository {
       query['q'] = search.trim();
     }
 
-
-    final data = await _client.get(basePath, queryParameters: query.isEmpty ? null : query);
+    final data = await _client.get(
+      basePath,
+      queryParameters: query.isEmpty ? null : query,
+    );
     if (data is! List) {
-      throw ApiException(500, 'Respuesta inválida al listar productos', data: data);
+      throw ApiException(
+        500,
+        'Respuesta inválida al listar productos',
+        data: data,
+      );
     }
 
     _idByCacheKey.clear();
@@ -44,75 +42,49 @@ class ApiProductRepository implements ProductRepository {
       _cacheId(product, item);
     }
     return products;
-
-    final data = await _client.get(
-      _basePath,
-      queryParameters: query.isEmpty ? null : query,
-    );
-    if (data is List) {
-      return data
-          .whereType<Map<String, dynamic>>()
-          .map(Product.fromJson)
-          .toList(growable: false);
-    }
-    throw const FormatException('Respuesta inesperada al listar productos');
-
   }
 
   @override
   Future<Product> createProduct(Product p) async {
-
     final data = await _client.post(basePath, body: _toJson(p));
     if (data is! Map<String, dynamic>) {
-      throw ApiException(500, 'Respuesta inválida al crear producto', data: data);
+      throw ApiException(
+        500,
+        'Respuesta inválida al crear producto',
+        data: data,
+      );
     }
     final created = _fromJson(data);
     _cacheId(created, data);
     return created;
-
-    final payload = p.toJson();
-    final data = await _client.post(_basePath, body: payload);
-    if (data is Map<String, dynamic>) {
-      return Product.fromJson(data);
-    }
-    throw const FormatException('Respuesta inesperada al crear producto');
-
   }
 
   @override
   Future<Product> updateProduct(Product p) async {
-
     final id = _lookupId(p);
     if (id == null) {
-      throw ApiException(400, 'No se encontró identificador para el producto ${p.name}');
+      throw ApiException(
+        400,
+        'No se encontró identificador para el producto ${p.name}',
+      );
     }
     final data = await _client.put('$basePath/$id', body: _toJson(p));
     if (data is! Map<String, dynamic>) {
-      throw ApiException(500, 'Respuesta inválida al actualizar producto', data: data);
+      throw ApiException(
+        500,
+        'Respuesta inválida al actualizar producto',
+        data: data,
+      );
     }
     final updated = _fromJson(data);
     _cacheId(updated, data);
     return updated;
-
-    final id = p.id;
-    if (id == null || id.isEmpty) {
-      throw const ArgumentError('El producto debe tener un id para actualizarse');
-    }
-    final data = await _client.put(
-      '$_basePath/${Uri.encodeComponent(id)}',
-      body: p.toJson(),
-    );
-    if (data is Map<String, dynamic>) {
-      return Product.fromJson(data);
-    }
-    throw const FormatException('Respuesta inesperada al actualizar producto');
-
   }
 
   @override
   Future<void> deleteProduct(String productId) async {
-
-    final id = productId.isNotEmpty ? (_idByCacheKey[productId] ?? productId) : null;
+    final id =
+        productId.isNotEmpty ? (_idByCacheKey[productId] ?? productId) : null;
     if (id == null) {
       throw ApiException(400, 'ID de producto inválido');
     }
@@ -169,8 +141,4 @@ class ApiProductRepository implements ProductRepository {
         'cantidad': product.cantidad,
         'estado': product.estado,
       };
-
-    await _client.delete('$_basePath/${Uri.encodeComponent(productId)}');
-  }
-
 }


### PR DESCRIPTION
## Summary
- remove the outdated ApiProductRepository implementation that relied on Product.fromJson
- retain the newer repository that manages cached IDs and JSON helpers while pointing to /api/clientes

## Testing
- dart analyze *(fails: `dart` command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cbfea9d1d8832f9bf95abc9cdb853d