### PR TITLE
Clean profile API repo implementation

### DIFF
--- a/lib/services/profile_repo_api.dart
+++ b/lib/services/profile_repo_api.dart
@@ -3,7 +3,6 @@ import 'api_client.dart';
 import 'profile_repository.dart';
 
 class ApiProfileRepository implements ProfileRepository {
-
   ApiProfileRepository(
     this._client, {
     this.mePath = '/api/profile/me',
@@ -19,25 +18,10 @@ class ApiProfileRepository implements ProfileRepository {
       throw ApiException(500, 'Respuesta inválida al obtener perfil', data: data);
     }
     return _usuarioFromJson(data);
-
-  ApiProfileRepository(this._client);
-
-  final ApiClient _client;
-  static const String _mePath = '/api/me';
-
-  @override
-  Future<Usuario> getMe() async {
-    final data = await _client.get(_mePath);
-    if (data is Map<String, dynamic>) {
-      return Usuario.fromJson(data);
-    }
-    throw const FormatException('Respuesta inesperada al obtener el perfil');
-
   }
 
   @override
   Future<Usuario> updateMe(Usuario u) async {
-
     final data = await _client.put(mePath, body: _usuarioToJson(u));
     if (data is! Map<String, dynamic>) {
       throw ApiException(500, 'Respuesta inválida al actualizar perfil', data: data);
@@ -71,12 +55,4 @@ class ApiProfileRepository implements ProfileRepository {
         if (u.phone != null) 'phone': u.phone,
         if (u.avatarUrl != null) 'avatarUrl': u.avatarUrl,
       };
-
-    final data = await _client.put(_mePath, body: u.toJson());
-    if (data is Map<String, dynamic>) {
-      return Usuario.fromJson(data);
-    }
-    throw const FormatException('Respuesta inesperada al actualizar el perfil');
-  }
-
 }


### PR DESCRIPTION
## Summary
- remove the legacy ApiProfileRepository implementation that relied on _mePath and Usuario.fromJson
- retain the newer JSON helper-based serialization methods for fetching and updating the current user profile

## Testing
- dart analyze *(fails: `dart` command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cbfead9224832f88ea2c32b39ae19a