### PR TITLE
Align product API mapping with cliente schema and update UI

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -60,6 +60,10 @@ class MyApp extends StatelessWidget {
       final dummyProducts = <Product>[
         const Product(
           name: "Zapatos deportivos",
+          lastName: "Demo",
+          email: "zapatos@example.com",
+          phone: "+504 1111-1111",
+          address: "Boulevard Centro 123",
           price: 59.99,
           imageUrl: "https://picsum.photos/seed/zapatos/600/400",
           cantidad: 10,
@@ -67,6 +71,10 @@ class MyApp extends StatelessWidget {
         ),
         const Product(
           name: "Camiseta básica",
+          lastName: "Demo",
+          email: "camiseta@example.com",
+          phone: "+504 2222-2222",
+          address: "Calle Las Flores 456",
           price: 19.99,
           imageUrl: "https://picsum.photos/seed/camiseta/600/400",
           cantidad: 20,
@@ -74,6 +82,10 @@ class MyApp extends StatelessWidget {
         ),
         const Product(
           name: "Pantalón de mezclilla",
+          lastName: "Demo",
+          email: "pantalon@example.com",
+          phone: "+504 3333-3333",
+          address: "Colonia Primavera 789",
           price: 39.99,
           imageUrl: "https://picsum.photos/seed/pantalon/600/400",
           cantidad: 15,

--- a/lib/models/product.dart
+++ b/lib/models/product.dart
@@ -5,6 +5,10 @@ class Product {
   final String imageUrl;
   final int cantidad;
   final String estado;
+  final String lastName;
+  final String email;
+  final String phone;
+  final String address;
 
   const Product({
     this.id,
@@ -13,6 +17,10 @@ class Product {
     required this.imageUrl,
     required this.cantidad,
     required this.estado,
+    this.lastName = '',
+    this.email = '',
+    this.phone = '',
+    this.address = '',
   });
 
   factory Product.fromJson(Map<String, dynamic> json) {
@@ -50,7 +58,14 @@ class Product {
         fallback: '',
       ),
       cantidad: _readInt(json['cantidad'] ?? json['stock']),
-      estado: _readString(json['estado'] ?? json['status'] ?? json['estadoProducto'], fallback: 'Activo'),
+      estado: _readString(
+        json['estado'] ?? json['status'] ?? json['estadoProducto'],
+        fallback: 'Activo',
+      ),
+      lastName: _readString(json['apellido'] ?? json['lastName'] ?? json['apellidos'], fallback: ''),
+      email: _readString(json['email'] ?? json['correo'] ?? json['correoElectronico'], fallback: ''),
+      phone: _readString(json['telefono'] ?? json['phone'] ?? json['celular'], fallback: ''),
+      address: _readString(json['direccion'] ?? json['address'] ?? json['domicilio'], fallback: ''),
     );
   }
 
@@ -58,10 +73,15 @@ class Product {
     return {
       if (id != null) 'id': id,
       'name': name,
+      'nombre': name,
       'price': price,
       'imageUrl': imageUrl,
       'cantidad': cantidad,
       'estado': estado,
+      'apellido': lastName,
+      'email': email,
+      'telefono': phone,
+      'direccion': address,
     };
   }
 
@@ -72,6 +92,10 @@ class Product {
     String? imageUrl,
     int? cantidad,
     String? estado,
+    String? lastName,
+    String? email,
+    String? phone,
+    String? address,
   }) {
     return Product(
       id: id ?? this.id,
@@ -80,6 +104,10 @@ class Product {
       imageUrl: imageUrl ?? this.imageUrl,
       cantidad: cantidad ?? this.cantidad,
       estado: estado ?? this.estado,
+      lastName: lastName ?? this.lastName,
+      email: email ?? this.email,
+      phone: phone ?? this.phone,
+      address: address ?? this.address,
     );
   }
 }

--- a/lib/screens/add_product_screen.dart
+++ b/lib/screens/add_product_screen.dart
@@ -11,6 +11,10 @@ class AddProductScreen extends StatefulWidget {
 class _AddProductScreenState extends State<AddProductScreen> {
   final _formKey = GlobalKey<FormState>();
   final _nameController = TextEditingController();
+  final _lastNameController = TextEditingController();
+  final _emailController = TextEditingController();
+  final _phoneController = TextEditingController();
+  final _addressController = TextEditingController();
   final _priceController = TextEditingController();
   final _imageController = TextEditingController();
   final _cantidadController = TextEditingController();
@@ -18,6 +22,10 @@ class _AddProductScreenState extends State<AddProductScreen> {
   @override
   void dispose() {
     _nameController.dispose();
+    _lastNameController.dispose();
+    _emailController.dispose();
+    _phoneController.dispose();
+    _addressController.dispose();
     _priceController.dispose();
     _imageController.dispose();
     _cantidadController.dispose();
@@ -29,14 +37,22 @@ class _AddProductScreenState extends State<AddProductScreen> {
 
     final product = Product(
       name: _nameController.text.trim(),
+      lastName: _lastNameController.text.trim(),
+      email: _emailController.text.trim(),
+      phone: _phoneController.text.trim(),
+      address: _addressController.text.trim(),
       price: double.parse(_priceController.text.trim()),
       imageUrl: _imageController.text.trim(),
       cantidad: int.parse(_cantidadController.text.trim()),
       estado: "Activo",
     );
 
+    final fullName = [product.name, product.lastName]
+        .where((element) => element.isNotEmpty)
+        .join(' ')
+        .trim();
     ScaffoldMessenger.of(context).showSnackBar(
-      SnackBar(content: Text("${product.name} agregado (demo)")),
+      SnackBar(content: Text("${fullName.isEmpty ? product.name : fullName} agregado (demo)")),
     );
     Navigator.pop(context, product); // devolvemos el producto creado
   }
@@ -58,6 +74,52 @@ class _AddProductScreenState extends State<AddProductScreen> {
                   decoration: const InputDecoration(
                     labelText: "Nombre",
                     prefixIcon: Icon(Icons.shopping_bag),
+                  ),
+                  validator: (v) => v == null || v.trim().isEmpty ? "Campo obligatorio" : null,
+                ),
+                const SizedBox(height: 15),
+                TextFormField(
+                  controller: _lastNameController,
+                  textInputAction: TextInputAction.next,
+                  decoration: const InputDecoration(
+                    labelText: "Apellido",
+                    prefixIcon: Icon(Icons.badge),
+                  ),
+                  validator: (v) => v == null || v.trim().isEmpty ? "Campo obligatorio" : null,
+                ),
+                const SizedBox(height: 15),
+                TextFormField(
+                  controller: _emailController,
+                  keyboardType: TextInputType.emailAddress,
+                  textInputAction: TextInputAction.next,
+                  decoration: const InputDecoration(
+                    labelText: "Email",
+                    prefixIcon: Icon(Icons.email),
+                  ),
+                  validator: (v) {
+                    if (v == null || v.trim().isEmpty) return "Campo obligatorio";
+                    if (!v.contains('@')) return "Email inválido";
+                    return null;
+                  },
+                ),
+                const SizedBox(height: 15),
+                TextFormField(
+                  controller: _phoneController,
+                  keyboardType: TextInputType.phone,
+                  textInputAction: TextInputAction.next,
+                  decoration: const InputDecoration(
+                    labelText: "Teléfono",
+                    prefixIcon: Icon(Icons.phone),
+                  ),
+                  validator: (v) => v == null || v.trim().isEmpty ? "Campo obligatorio" : null,
+                ),
+                const SizedBox(height: 15),
+                TextFormField(
+                  controller: _addressController,
+                  textInputAction: TextInputAction.next,
+                  decoration: const InputDecoration(
+                    labelText: "Dirección",
+                    prefixIcon: Icon(Icons.location_on),
                   ),
                   validator: (v) => v == null || v.trim().isEmpty ? "Campo obligatorio" : null,
                 ),

--- a/lib/screens/edit_product_screen.dart
+++ b/lib/screens/edit_product_screen.dart
@@ -12,6 +12,10 @@ class EditProductScreen extends StatefulWidget {
 class _EditProductScreenState extends State<EditProductScreen> {
   final _formKey = GlobalKey<FormState>();
   late TextEditingController _nameController;
+  late TextEditingController _lastNameController;
+  late TextEditingController _emailController;
+  late TextEditingController _phoneController;
+  late TextEditingController _addressController;
   late TextEditingController _priceController;
   late TextEditingController _imageController;
   late TextEditingController _cantidadController;
@@ -20,6 +24,10 @@ class _EditProductScreenState extends State<EditProductScreen> {
   void initState() {
     super.initState();
     _nameController = TextEditingController(text: widget.product.name);
+    _lastNameController = TextEditingController(text: widget.product.lastName);
+    _emailController = TextEditingController(text: widget.product.email);
+    _phoneController = TextEditingController(text: widget.product.phone);
+    _addressController = TextEditingController(text: widget.product.address);
     _priceController = TextEditingController(text: widget.product.price.toString());
     _imageController = TextEditingController(text: widget.product.imageUrl);
     _cantidadController = TextEditingController(text: widget.product.cantidad.toString());
@@ -28,6 +36,10 @@ class _EditProductScreenState extends State<EditProductScreen> {
   @override
   void dispose() {
     _nameController.dispose();
+    _lastNameController.dispose();
+    _emailController.dispose();
+    _phoneController.dispose();
+    _addressController.dispose();
     _priceController.dispose();
     _imageController.dispose();
     _cantidadController.dispose();
@@ -40,14 +52,22 @@ class _EditProductScreenState extends State<EditProductScreen> {
     final updated = Product(
       id: widget.product.id,
       name: _nameController.text.trim(),
+      lastName: _lastNameController.text.trim(),
+      email: _emailController.text.trim(),
+      phone: _phoneController.text.trim(),
+      address: _addressController.text.trim(),
       price: double.parse(_priceController.text.trim()),
       imageUrl: _imageController.text.trim(),
       cantidad: int.parse(_cantidadController.text.trim()),
       estado: widget.product.estado,
     );
 
+    final fullName = [updated.name, updated.lastName]
+        .where((element) => element.isNotEmpty)
+        .join(' ')
+        .trim();
     ScaffoldMessenger.of(context).showSnackBar(
-      SnackBar(content: Text("${updated.name} actualizado (demo)")),
+      SnackBar(content: Text("${fullName.isEmpty ? updated.name : fullName} actualizado (demo)")),
     );
     Navigator.pop(context, updated); // devolvemos el actualizado
   }
@@ -69,6 +89,52 @@ class _EditProductScreenState extends State<EditProductScreen> {
                   decoration: const InputDecoration(
                     labelText: "Nombre",
                     prefixIcon: Icon(Icons.shopping_bag),
+                  ),
+                  validator: (v) => v == null || v.trim().isEmpty ? "Campo obligatorio" : null,
+                ),
+                const SizedBox(height: 15),
+                TextFormField(
+                  controller: _lastNameController,
+                  textInputAction: TextInputAction.next,
+                  decoration: const InputDecoration(
+                    labelText: "Apellido",
+                    prefixIcon: Icon(Icons.badge),
+                  ),
+                  validator: (v) => v == null || v.trim().isEmpty ? "Campo obligatorio" : null,
+                ),
+                const SizedBox(height: 15),
+                TextFormField(
+                  controller: _emailController,
+                  keyboardType: TextInputType.emailAddress,
+                  textInputAction: TextInputAction.next,
+                  decoration: const InputDecoration(
+                    labelText: "Email",
+                    prefixIcon: Icon(Icons.email),
+                  ),
+                  validator: (v) {
+                    if (v == null || v.trim().isEmpty) return "Campo obligatorio";
+                    if (!v.contains('@')) return "Email inválido";
+                    return null;
+                  },
+                ),
+                const SizedBox(height: 15),
+                TextFormField(
+                  controller: _phoneController,
+                  keyboardType: TextInputType.phone,
+                  textInputAction: TextInputAction.next,
+                  decoration: const InputDecoration(
+                    labelText: "Teléfono",
+                    prefixIcon: Icon(Icons.phone),
+                  ),
+                  validator: (v) => v == null || v.trim().isEmpty ? "Campo obligatorio" : null,
+                ),
+                const SizedBox(height: 15),
+                TextFormField(
+                  controller: _addressController,
+                  textInputAction: TextInputAction.next,
+                  decoration: const InputDecoration(
+                    labelText: "Dirección",
+                    prefixIcon: Icon(Icons.location_on),
                   ),
                   validator: (v) => v == null || v.trim().isEmpty ? "Campo obligatorio" : null,
                 ),

--- a/lib/screens/main_screen.dart
+++ b/lib/screens/main_screen.dart
@@ -103,7 +103,16 @@ class _MainScreenState extends State<MainScreen> {
     if (a.id != null && b.id != null) {
       return a.id == b.id;
     }
-    return a.name.toLowerCase() == b.name.toLowerCase();
+    return _productDisplayName(a).toLowerCase() ==
+        _productDisplayName(b).toLowerCase();
+  }
+
+  String _productDisplayName(Product product) {
+    final fullName = [product.name, product.lastName]
+        .where((element) => element.isNotEmpty)
+        .join(' ')
+        .trim();
+    return fullName.isEmpty ? product.name : fullName;
   }
 
   int _availableStockOf(Product product) {
@@ -126,7 +135,11 @@ class _MainScreenState extends State<MainScreen> {
 
     if (stock <= 0 || maxAdd <= 0) {
       ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text("No hay stock disponible de ${product.name}. Stock: $stock")),
+        SnackBar(
+          content: Text(
+            "No hay stock disponible de ${_productDisplayName(product)}. Stock: $stock",
+          ),
+        ),
       );
       return;
     }
@@ -151,7 +164,7 @@ class _MainScreenState extends State<MainScreen> {
     // Feedback + acción para ver el carrito
     ScaffoldMessenger.of(context).showSnackBar(
       SnackBar(
-        content: Text("${product.name} agregado (x$safeQty)"),
+        content: Text("${_productDisplayName(product)} agregado (x$safeQty)"),
         action: SnackBarAction(
           label: "Ver carrito",
           onPressed: () {

--- a/lib/screens/product_detail_screen.dart
+++ b/lib/screens/product_detail_screen.dart
@@ -29,6 +29,7 @@ class _ProductDetailScreenState extends State<ProductDetailScreen> {
   @override
   Widget build(BuildContext context) {
     final p = widget.product;
+    final fullName = [p.name, p.lastName].where((it) => it.isNotEmpty).join(' ').trim();
     final bool showForClient = !widget.isAdmin && p.cantidad < 5;
     final bool showForAdmin  = widget.isAdmin;
     final bool lowForAdmin   = p.cantidad < 10;
@@ -39,8 +40,34 @@ class _ProductDetailScreenState extends State<ProductDetailScreen> {
 
     final bool outOfStock = p.cantidad <= 0;
 
+    Widget infoRow(IconData icon, String label, String value) {
+      if (value.isEmpty) return const SizedBox.shrink();
+      return Padding(
+        padding: const EdgeInsets.symmetric(vertical: 6.0),
+        child: Row(
+          children: [
+            Icon(icon, size: 20, color: Colors.pink.shade400),
+            const SizedBox(width: 12),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(label, style: const TextStyle(fontSize: 12, color: Colors.grey)),
+                  const SizedBox(height: 2),
+                  Text(
+                    value,
+                    style: const TextStyle(fontSize: 15, fontWeight: FontWeight.w600),
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
+      );
+    }
+
     return Scaffold(
-      appBar: AppBar(title: Text(p.name)),
+      appBar: AppBar(title: Text(fullName.isEmpty ? p.name : fullName)),
       body: SingleChildScrollView(
         padding: const EdgeInsets.all(16.0),
         child: Column(
@@ -63,13 +90,33 @@ class _ProductDetailScreenState extends State<ProductDetailScreen> {
               ),
             ),
             const SizedBox(height: 20),
-            Text(p.name, style: const TextStyle(fontSize: 22, fontWeight: FontWeight.bold)),
+            Text(
+              fullName.isEmpty ? p.name : fullName,
+              style: const TextStyle(fontSize: 22, fontWeight: FontWeight.bold),
+            ),
             const SizedBox(height: 10),
             Text(
               "\$${p.price.toStringAsFixed(2)}",
               style: const TextStyle(fontSize: 20, fontWeight: FontWeight.w600, color: Colors.pink),
             ),
             const SizedBox(height: 12),
+
+            if (p.lastName.isNotEmpty ||
+                p.email.isNotEmpty ||
+                p.phone.isNotEmpty ||
+                p.address.isNotEmpty) ...[
+              const Divider(height: 32),
+              const Text(
+                "Información del cliente",
+                style: TextStyle(fontSize: 18, fontWeight: FontWeight.w700),
+              ),
+              const SizedBox(height: 4),
+              infoRow(Icons.badge, "Apellido", p.lastName),
+              infoRow(Icons.email, "Email", p.email),
+              infoRow(Icons.phone, "Teléfono", p.phone),
+              infoRow(Icons.location_on, "Dirección", p.address),
+              const SizedBox(height: 12),
+            ],
 
             if (showForAdmin || showForClient)
               Row(

--- a/lib/screens/product_list_screen.dart
+++ b/lib/screens/product_list_screen.dart
@@ -27,9 +27,19 @@ class _ProductListScreenState extends State<ProductListScreen> {
 
   @override
   Widget build(BuildContext context) {
+    final query = _query.trim().toLowerCase();
     final filtered = widget.products.where((p) {
-      if (_query.isEmpty) return true;
-      return p.name.toLowerCase().contains(_query.toLowerCase());
+      if (query.isEmpty) return true;
+      final fullName =
+          [p.name, p.lastName].where((element) => element.isNotEmpty).join(' ').trim();
+      final searchTargets = <String>{
+        p.name,
+        p.lastName,
+        fullName,
+        p.email,
+        p.phone,
+      }..removeWhere((value) => value.trim().isEmpty);
+      return searchTargets.any((value) => value.toLowerCase().contains(query));
     }).toList();
 
     return Padding(

--- a/lib/services/order_repo_api.dart
+++ b/lib/services/order_repo_api.dart
@@ -164,7 +164,12 @@ class ApiOrderRepository implements OrderRepository {
     }
 
     return Product(
-      name: _string(json['name'] ?? json['nombre']),
+      id: json['id']?.toString(),
+      name: _string(json['nombre'] ?? json['name']),
+      lastName: _string(json['apellido'] ?? json['lastName']),
+      email: _string(json['email'] ?? json['correo']),
+      phone: _string(json['telefono'] ?? json['phone']),
+      address: _string(json['direccion'] ?? json['address']),
       price: _double(json['price']),
       imageUrl: _string(json['imageUrl'] ?? json['imagen']),
       cantidad: _int(json['cantidad'] ?? json['stock']),
@@ -181,7 +186,13 @@ class ApiOrderRepository implements OrderRepository {
       );
 
   Map<String, dynamic> _productToJson(Product product) => {
+        'nombre': product.name,
         'name': product.name,
+        'apellido': product.lastName,
+        'lastName': product.lastName,
+        'email': product.email,
+        'telefono': product.phone,
+        'direccion': product.address,
         'price': product.price,
         'imageUrl': product.imageUrl,
         'cantidad': product.cantidad,

--- a/lib/services/product_repo_api.dart
+++ b/lib/services/product_repo_api.dart
@@ -105,7 +105,13 @@ class ApiProductRepository implements ProductRepository {
     return _idByCacheKey[key];
   }
 
-  String _cacheKey(Product product) => product.name.toLowerCase();
+  String _cacheKey(Product product) {
+    final fullName = [product.name, product.lastName]
+        .where((element) => element.isNotEmpty)
+        .join(' ')
+        .trim();
+    return (fullName.isEmpty ? product.name : fullName).toLowerCase();
+  }
 
   Product _fromJson(Map<String, dynamic> json) {
     double _double(dynamic value) {
@@ -126,7 +132,12 @@ class ApiProductRepository implements ProductRepository {
     }
 
     return Product(
-      name: _string(json['name'] ?? json['nombre']),
+      id: json['id']?.toString(),
+      name: _string(json['nombre'] ?? json['name']),
+      lastName: _string(json['apellido'] ?? json['lastName']),
+      email: _string(json['email'] ?? json['correo']),
+      phone: _string(json['telefono'] ?? json['phone']),
+      address: _string(json['direccion'] ?? json['address']),
       price: _double(json['price']),
       imageUrl: _string(json['imageUrl'] ?? json['imagen']),
       cantidad: _int(json['cantidad'] ?? json['stock']),
@@ -135,10 +146,15 @@ class ApiProductRepository implements ProductRepository {
   }
 
   Map<String, dynamic> _toJson(Product product) => {
+        'nombre': product.name,
         'name': product.name,
+        'apellido': product.lastName,
+        'email': product.email,
+        'telefono': product.phone,
+        'direccion': product.address,
+        'estado': product.estado,
         'price': product.price,
         'imageUrl': product.imageUrl,
         'cantidad': product.cantidad,
-        'estado': product.estado,
       };
 }

--- a/lib/services/product_repo_dummy.dart
+++ b/lib/services/product_repo_dummy.dart
@@ -20,7 +20,14 @@ class DummyProductRepository implements ProductRepository {
     }
     final q = search.toLowerCase();
     return _store
-        .where((p) => p.name.toLowerCase().contains(q))
+        .where((p) {
+          final fullName = [p.name, p.lastName]
+              .where((element) => element.isNotEmpty)
+              .join(' ')
+              .trim()
+              .toLowerCase();
+          return fullName.contains(q);
+        })
         .toList(growable: false);
   }
 
@@ -30,7 +37,13 @@ class DummyProductRepository implements ProductRepository {
       if (a.id != null && b.id != null) {
         return a.id == b.id;
       }
-      return a.name.toLowerCase() == b.name.toLowerCase();
+      String _fullName(Product product) =>
+          [product.name, product.lastName]
+              .where((element) => element.isNotEmpty)
+              .join(' ')
+              .trim()
+              .toLowerCase();
+      return _fullName(a) == _fullName(b);
     }
 
     // Evita duplicados por id (si existe) o por nombre en modo dummy
@@ -49,7 +62,14 @@ class DummyProductRepository implements ProductRepository {
         final idx = _store.indexWhere((x) => x.id == product.id);
         if (idx != -1) return idx;
       }
-      return _store.indexWhere((x) => x.name.toLowerCase() == product.name.toLowerCase());
+      String _fullName(Product product) =>
+          [product.name, product.lastName]
+              .where((element) => element.isNotEmpty)
+              .join(' ')
+              .trim()
+              .toLowerCase();
+      final target = _fullName(product);
+      return _store.indexWhere((x) => _fullName(x) == target);
     }
 
     final idx = _indexOf(p);
@@ -65,7 +85,9 @@ class DummyProductRepository implements ProductRepository {
       if (x.id != null && x.id == productId) {
         return true;
       }
-      return x.name.toLowerCase() == productId.toLowerCase();
+      final fullName =
+          [x.name, x.lastName].where((element) => element.isNotEmpty).join(' ').trim().toLowerCase();
+      return fullName == productId.toLowerCase();
     });
     if (_store.length == before) {
       throw Exception('Producto no encontrado');

--- a/lib/widgets/product_card.dart
+++ b/lib/widgets/product_card.dart
@@ -59,11 +59,27 @@ class ProductCard extends StatelessWidget {
                     maxLines: 1,
                     overflow: TextOverflow.ellipsis,
                   ),
+                  if (product.lastName.isNotEmpty)
+                    Text(
+                      product.lastName,
+                      style: const TextStyle(fontSize: 13, color: Colors.grey),
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                    ),
                   const SizedBox(height: 4),
                   Text(
                     "\$${product.price.toStringAsFixed(2)}",
                     style: const TextStyle(color: Colors.pink, fontSize: 14, fontWeight: FontWeight.w600),
                   ),
+                  if (product.email.isNotEmpty) ...[
+                    const SizedBox(height: 4),
+                    Text(
+                      product.email,
+                      style: const TextStyle(fontSize: 12, color: Colors.black87),
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                  ],
                   if (showInventory) ...[
                     const SizedBox(height: 6),
                     Row(


### PR DESCRIPTION
## Summary
- add the cliente schema fields to the Product model and update the API mappers to send and read nombre, apellido, email, teléfono y dirección
- keep dummy data/repositories consistent by using the full nombre+apellido as cache/search keys and seeding sample contact data
- expand the product screens to capture and show the backend-compatible contact fields alongside the existing catalog attributes

## Testing
- Not run (flutter tooling is not available in the container)


------
https://chatgpt.com/codex/tasks/task_e_68cc8bc3e4bc832f9231f36b0277bf73