### PR TITLE
Temporarily disable API orders module

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -7,7 +7,6 @@ import 'services/api_client.dart';
 import 'services/auth_service.dart';
 import 'services/auth_service_api.dart';
 import 'services/auth_service_dummy.dart';
-import 'services/order_repo_api.dart';
 import 'services/order_repo_dummy.dart';
 import 'services/order_repository.dart';
 import 'services/product_repo_api.dart';
@@ -17,6 +16,11 @@ import 'services/product_repository.dart';
 const bool kUseMockServices = bool.fromEnvironment(
   'USE_MOCK_SERVICES',
   defaultValue: false,
+);
+
+const bool kOrdersFeatureEnabled = bool.fromEnvironment(
+  'ORDERS_FEATURE_ENABLED',
+  defaultValue: kUseMockServices,
 );
 
 const String kApiBaseUrl = String.fromEnvironment(
@@ -87,7 +91,7 @@ class MyApp extends StatelessWidget {
     } else {
       authService = ApiAuthService(_apiClient);
       productRepo = ApiProductRepository(_apiClient);
-      orderRepo = ApiOrderRepository(_apiClient);
+      orderRepo = DummyOrderRepository([]);
     }
 
     return MaterialApp(
@@ -132,6 +136,7 @@ class MyApp extends StatelessWidget {
         authService: authService,
         productRepository: productRepo,
         orderRepository: orderRepo,
+        ordersEnabled: kOrdersFeatureEnabled,
       ),
     );
   }

--- a/lib/screens/login_screen.dart
+++ b/lib/screens/login_screen.dart
@@ -15,12 +15,14 @@ class LoginScreen extends StatefulWidget {
   final AuthService authService;
   final ProductRepository productRepository;
   final OrderRepository orderRepository;
+  final bool ordersEnabled;
 
   const LoginScreen({
     super.key,
     required this.authService,
     required this.productRepository,
     required this.orderRepository,
+    required this.ordersEnabled,
   });
 
   @override
@@ -55,7 +57,9 @@ class _LoginScreenState extends State<LoginScreen> {
       final products = await widget.productRepository.fetchProducts();
 
       // Sembrar pedidos demo si es cliente (para historial/analytics)
-      final seedOrders = _seedOrdersIfNeeded(user, products);
+      final seedOrders = widget.ordersEnabled
+          ? _seedOrdersIfNeeded(user, products)
+          : <Order>[];
 
       if (!mounted) return;
       Navigator.pushReplacement(
@@ -68,6 +72,7 @@ class _LoginScreenState extends State<LoginScreen> {
             productRepository: widget.productRepository,
             orderRepository: widget.orderRepository,
             authService: widget.authService,
+            ordersEnabled: widget.ordersEnabled,
           ),
         ),
       );

--- a/lib/screens/main_screen.dart
+++ b/lib/screens/main_screen.dart
@@ -33,6 +33,7 @@ class MainScreen extends StatefulWidget {
   final ProductRepository productRepository;
   final OrderRepository orderRepository;
   final AuthService authService;
+  final bool ordersEnabled;
 
   const MainScreen({
     super.key,
@@ -42,6 +43,7 @@ class MainScreen extends StatefulWidget {
     required this.productRepository,
     required this.orderRepository,
     required this.authService,
+    required this.ordersEnabled,
   });
 
   @override
@@ -60,6 +62,8 @@ class _MainScreenState extends State<MainScreen> {
   bool _loadingProducts = false;
   bool _loadingOrders = false;
 
+  bool get _ordersEnabled => widget.ordersEnabled;
+
   /// Si es admin real y NO está en "ver como cliente", se considera admin efectivo.
   bool _viewAsClient = false;
   bool get isActualAdmin => _currentUser.rol == "admin";
@@ -72,7 +76,9 @@ class _MainScreenState extends State<MainScreen> {
     _products = List<Product>.from(widget.productsInitialSnapshot);
     _orders = List<Order>.from(widget.ordersInitialSnapshot);
     _loadProducts();
-    _loadOrders();
+    if (_ordersEnabled) {
+      _loadOrders();
+    }
   }
 
   Future<void> _loadProducts() async {
@@ -87,6 +93,7 @@ class _MainScreenState extends State<MainScreen> {
   }
 
   Future<void> _loadOrders() async {
+    if (!_ordersEnabled) return;
     setState(() => _loadingOrders = true);
     try {
       final list = await widget.orderRepository.fetchOrders();
@@ -192,6 +199,10 @@ class _MainScreenState extends State<MainScreen> {
   // ---------- Pedidos ----------
 
   Future<void> _updateOrderStatus(String orderId, OrderStatus newStatus) async {
+    if (!_ordersEnabled) {
+      _showOrdersComingSoon();
+      return;
+    }
     await widget.orderRepository.updateStatus(orderId, newStatus);
     final idx = _orders.indexWhere((o) => o.id == orderId);
     if (idx == -1) return;
@@ -244,6 +255,46 @@ class _MainScreenState extends State<MainScreen> {
     );
   }
 
+  void _showOrdersComingSoon() {
+    if (!mounted) return;
+    ScaffoldMessenger.of(context).showSnackBar(
+      const SnackBar(
+        content: Text('El módulo de pedidos estará disponible próximamente.'),
+      ),
+    );
+  }
+
+  Widget _buildOrdersComingSoon() {
+    final theme = Theme.of(context);
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(32),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(
+              Icons.local_shipping_outlined,
+              size: 72,
+              color: theme.primaryColor,
+            ),
+            const SizedBox(height: 16),
+            Text(
+              'Pedidos próximamente',
+              style: theme.textTheme.titleLarge?.copyWith(fontWeight: FontWeight.bold),
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: 12),
+            Text(
+              'Estamos trabajando en la gestión de pedidos. Muy pronto estará disponible.',
+              style: theme.textTheme.bodyMedium?.copyWith(color: Colors.grey[600]),
+              textAlign: TextAlign.center,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
   // ---------- Logout ----------
 
   Future<void> _logout() async {
@@ -284,6 +335,7 @@ class _MainScreenState extends State<MainScreen> {
       authService: widget.authService,
       productRepository: widget.productRepository,
       orderRepository: widget.orderRepository,
+      ordersEnabled: widget.ordersEnabled,
     ),
   ),
   (route) => false,
@@ -296,6 +348,16 @@ class _MainScreenState extends State<MainScreen> {
   @override
   Widget build(BuildContext context) {
     // Páginas según rol
+    final Widget adminOrdersTab = !_ordersEnabled
+        ? _buildOrdersComingSoon()
+        : _loadingOrders
+            ? const Center(child: CircularProgressIndicator())
+            : AdminOrdersScreen(
+                orders: _orders,
+                onUpdateStatus: _updateOrderStatus,
+                showAppBar: false,
+              );
+
     final List<Widget> screens = isAdminEffective
         ? [
             // 0) Productos (admin: sin carrito)
@@ -307,14 +369,8 @@ class _MainScreenState extends State<MainScreen> {
                     onAddToCart: (_, __) {}, // admin no compra
                     onEditProduct: _editProduct,
                   ),
-            // 1) Pedidos
-            _loadingOrders
-                ? const Center(child: CircularProgressIndicator())
-                : AdminOrdersScreen(
-                    orders: _orders,
-                    onUpdateStatus: _updateOrderStatus,
-                    showAppBar: false,
-                  ),
+            // 1) Pedidos o mensaje temporal
+            adminOrdersTab,
             // 2) Estadísticas
             AdminAnalyticsScreen(orders: _orders),
             // 3) Perfil
@@ -331,6 +387,7 @@ class _MainScreenState extends State<MainScreen> {
               onEditProfile: _openEditProfile,
               onOpenOrderHistory: null, // admin no tiene historial de compras
               onLogout: _logout,
+              orderHistorySubtitle: null,
             ),
           ]
         : [
@@ -360,8 +417,11 @@ class _MainScreenState extends State<MainScreen> {
                     }
                   : null,
               onEditProfile: _openEditProfile,
-              onOpenOrderHistory: _openOrderHistory,
+              onOpenOrderHistory:
+                  _ordersEnabled ? _openOrderHistory : _showOrdersComingSoon,
               onLogout: _logout,
+              orderHistorySubtitle:
+                  _ordersEnabled ? null : 'Disponible próximamente',
             ),
           ];
 

--- a/lib/screens/profile_screen.dart
+++ b/lib/screens/profile_screen.dart
@@ -13,6 +13,7 @@ class ProfileScreen extends StatelessWidget {
   final VoidCallback? onEditProfile;
   final VoidCallback? onOpenOrderHistory; // cliente
   final VoidCallback? onLogout;
+  final String? orderHistorySubtitle;
 
   const ProfileScreen({
     super.key,
@@ -23,6 +24,7 @@ class ProfileScreen extends StatelessWidget {
     this.onEditProfile,
     this.onOpenOrderHistory,
     this.onLogout,
+    this.orderHistorySubtitle,
   });
 
   @override
@@ -87,6 +89,9 @@ class ProfileScreen extends StatelessWidget {
                 child: ListTile(
                   leading: const Icon(Icons.history, color: Colors.pink),
                   title: const Text("Historial de compras"),
+                  subtitle: orderHistorySubtitle != null
+                      ? Text(orderHistorySubtitle!, style: const TextStyle(color: Colors.grey))
+                      : null,
                   trailing: const Icon(Icons.arrow_forward_ios, size: 16),
                   onTap: onOpenOrderHistory,
                 ),


### PR DESCRIPTION
## Summary
- add a compile-time flag to toggle the orders feature and always inject the dummy repository while the API module is unavailable
- propagate the flag through the login and main screens to skip order API calls and replace the admin tab with a “próximamente” message when disabled
- update the profile screen to surface the availability notice on the order history entry for clients

## Testing
- not run (Flutter tooling is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68cc8d3cb818832f96ca1d2273b7cbca