### PR TITLE
Add authenticated profile endpoints

### DIFF
--- a/controllers/profileController.js
+++ b/controllers/profileController.js
@@ -1,0 +1,88 @@
+const authRepo = require('../repositories/authRepository');
+
+const normalizarOpcional = (valor) => {
+  if (valor === undefined) return undefined;
+  if (valor === null) return null;
+  if (typeof valor === 'string') {
+    const trimmed = valor.trim();
+    return trimmed === '' ? null : trimmed;
+  }
+  const str = String(valor).trim();
+  return str === '' ? null : str;
+};
+
+const getMe = async (req, res) => {
+  try {
+    const userId = req.user?.id;
+    if (!userId) return res.status(401).json({ error: 'No autorizado' });
+
+    const usuario = await authRepo.buscarUsuarioPorId(userId);
+    if (!usuario) return res.status(404).json({ error: 'Usuario no encontrado' });
+
+    res.json(usuario);
+  } catch (e) {
+    res.status(500).json({ error: e.message });
+  }
+};
+
+const updateMe = async (req, res) => {
+  try {
+    const userId = req.user?.id;
+    if (!userId) return res.status(401).json({ error: 'No autorizado' });
+
+    const body = req.body ?? {};
+    const patch = {};
+
+    if (Object.prototype.hasOwnProperty.call(body, 'nombre')) {
+      if (typeof body.nombre !== 'string' || body.nombre.trim() === '') {
+        return res.status(400).json({ error: 'Nombre inválido' });
+      }
+      patch.nombre = body.nombre.trim();
+    }
+
+    if (Object.prototype.hasOwnProperty.call(body, 'email')) {
+      if (typeof body.email !== 'string') {
+        return res.status(400).json({ error: 'Email inválido' });
+      }
+      const email = body.email.trim();
+      if (email === '' || !email.includes('@')) {
+        return res.status(400).json({ error: 'Email inválido' });
+      }
+      patch.email = email;
+    }
+
+    const phoneRaw = Object.prototype.hasOwnProperty.call(body, 'phone')
+      ? body.phone
+      : body.telefono;
+    if (phoneRaw !== undefined) {
+      patch.phone = normalizarOpcional(phoneRaw);
+    }
+
+    const avatarRaw = Object.prototype.hasOwnProperty.call(body, 'avatarUrl')
+      ? body.avatarUrl
+      : body.avatar;
+    if (avatarRaw !== undefined) {
+      patch.avatarUrl = normalizarOpcional(avatarRaw);
+    }
+
+    if (Object.keys(patch).length === 0) {
+      const actual = await authRepo.buscarUsuarioPorId(userId);
+      if (!actual) return res.status(404).json({ error: 'Usuario no encontrado' });
+      return res.json(actual);
+    }
+
+    if (patch.email) {
+      const yaExiste = await authRepo.existeEmail(patch.email, { excluirId: userId });
+      if (yaExiste) return res.status(409).json({ error: 'Email ya registrado' });
+    }
+
+    const actualizado = await authRepo.actualizarUsuario(userId, patch);
+    if (!actualizado) return res.status(404).json({ error: 'Usuario no encontrado' });
+
+    res.json(actualizado);
+  } catch (e) {
+    res.status(500).json({ error: e.message });
+  }
+};
+
+module.exports = { getMe, updateMe };

--- a/routes/index.js
+++ b/routes/index.js
@@ -4,6 +4,7 @@ const router = express.Router();
 // Rutas de módulos
 const authRoutes = require('./auth.routes');
 const clientesRoutes = require('./cliente.routes'); // si aún no la tienes, la pasamos después
+const profileRoutes = require('./profile.routes');
 
 // Healthcheck simple (opcional)
 router.get('/health', (_req, res) => res.json({ ok: true, ts: Date.now() }));
@@ -11,5 +12,6 @@ router.get('/health', (_req, res) => res.json({ ok: true, ts: Date.now() }));
 // Montaje con prefijo /api
 router.use('/api/auth', authRoutes);
 router.use('/api/clientes', clientesRoutes);
+router.use('/api/profile', profileRoutes);
 
 module.exports = router;

--- a/routes/profile.routes.js
+++ b/routes/profile.routes.js
@@ -1,0 +1,10 @@
+const express = require('express');
+const controller = require('../controllers/profileController');
+const { requiereAuth } = require('../middleware/authJwt');
+
+const r = express.Router();
+
+r.get('/me', requiereAuth, controller.getMe);
+r.put('/me', requiereAuth, controller.updateMe);
+
+module.exports = r;


### PR DESCRIPTION
## Summary
- add profile controller with `GET`/`PUT` actions for the authenticated user profile
- register the protected `/api/profile/me` routes and reuse the auth repository
- extend the auth repository helpers to expose profile fields and allow updates

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68d1e5a12634832fa0d2631d467b41b0