### PR TITLE
Use non-const MyApp in widget test

### DIFF
--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -4,7 +4,7 @@ import 'package:meysshop_front1/main.dart';
 
 void main() {
   testWidgets('Login screen shows welcome texts', (WidgetTester tester) async {
-    await tester.pumpWidget(const MyApp());
+    await tester.pumpWidget(MyApp());
     await tester.pumpAndSettle();
 
     expect(find.text('Bienvenido a Meysshop'), findsOneWidget);


### PR DESCRIPTION
## Summary
- update the widget test to instantiate `MyApp` without the `const` keyword so it uses the non-constant constructor

## Testing
- `flutter test` *(fails: flutter command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d1e5a0e304832fb149cc463831b86d