### PR TITLE
Fix models import path resolution

### DIFF
--- a/server.js
+++ b/server.js
@@ -21,7 +21,7 @@ app.get('/about', (req, res) => {
 app.get('/contact', (req, res) => {
     res.send('Contact Page')
 })
-const db = require('./models')
+const db = require('./models/index.js')
 const indexRoutes = require('./routes')
 
 app.use(cors({ origin: process.env.FRONTEND_URL ?? '*', credentials: true }));


### PR DESCRIPTION
## Summary
- import the Sequelize models via the explicit `models/index.js` entry point to avoid implicit resolution issues

## Testing
- node server.js *(fails: Unable to connect to the database)*

------
https://chatgpt.com/codex/tasks/task_e_68d20ac4c838832f99e55fabe30bf57b