### PR TITLE
Add admin seeder and align sequelize paths

### DIFF
--- a/.sequelizerc
+++ b/.sequelizerc
@@ -1,8 +1,8 @@
 const path = require('path');
 
 module.exports = {
-    'config': path.resolve('./src/config', 'config.js'),
-    'models-path': path.resolve('./src/models'),
-    'migrations-path': path.resolve('./src/migrations'),
-    'seeders-path': path.resolve('./src/seeders')
-}
+  config: path.resolve('./config', 'config.js'),
+  'models-path': path.resolve('./models'),
+  'migrations-path': path.resolve('./migrations'),
+  'seeders-path': path.resolve('./seeders')
+};

--- a/seeders/20240101000000-create-admin.js
+++ b/seeders/20240101000000-create-admin.js
@@ -1,0 +1,24 @@
+'use strict';
+
+const bcrypt = require('bcrypt');
+
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    const hash = await bcrypt.hash('admin123', 10);
+
+    return queryInterface.bulkInsert('Usuarios', [
+      {
+        nombre: 'Admin',
+        email: 'admin@example.com',
+        hash,
+        rol: 'admin',
+        createdAt: new Date(),
+        updatedAt: new Date()
+      }
+    ]);
+  },
+
+  async down(queryInterface, Sequelize) {
+    return queryInterface.bulkDelete('Usuarios', { email: 'admin@example.com' });
+  }
+};


### PR DESCRIPTION
## Summary
- add a Sequelize seeder that inserts a default admin user with a bcrypt hash
- point the Sequelize CLI configuration to the existing config, models, migrations, and seeders folders so the new seeder is discoverable

## Testing
- npx sequelize-cli db:seed:all *(fails: requires database credentials/environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d2328ce4e0832fa04279781dd14991