### PR TITLE
Add http_parser dependency for MediaType usage

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -39,6 +39,7 @@ dependencies:
   share_plus: ^10.0.0
   fl_chart: ^0.69.0
   http: ^1.2.2
+  http_parser: ^4.0.2
   image_picker: ^1.0.7
 
 dev_dependencies:


### PR DESCRIPTION
## Summary
- add the http_parser dependency so MediaType can be used in the product API repository

## Testing
- not run (flutter is not available in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68d25a837be4832fb11719fdf8c8b6c8