### PR TITLE
Clean duplicate product list screen definitions

### DIFF
--- a/lib/screens/product_list_screen.dart
+++ b/lib/screens/product_list_screen.dart
@@ -1,4 +1,3 @@
-
 import 'package:flutter/material.dart';
 import '../models/product.dart';
 import '../models/product_form_result.dart';
@@ -27,35 +26,6 @@ class ProductListScreen extends StatefulWidget {
 class _ProductListScreenState extends State<ProductListScreen> {
   String _query = "";
 
-
-import 'package:flutter/material.dart';
-import '../models/product.dart';
-import '../widgets/product_card.dart';
-import 'product_detail_screen.dart';
-import 'edit_product_screen.dart';
-
-class ProductListScreen extends StatefulWidget {
-  final List<Product> products;
-  final bool isAdmin;
-  final void Function(Product, int qty) onAddToCart;
-  final void Function(int index, Product updated) onEditProduct;
-
-  const ProductListScreen({
-    super.key,
-    required this.products,
-    required this.isAdmin,
-    required this.onAddToCart,
-    required this.onEditProduct,
-  });
-
-  @override
-  State<ProductListScreen> createState() => _ProductListScreenState();
-}
-
-class _ProductListScreenState extends State<ProductListScreen> {
-  String _query = "";
-
-
   @override
   Widget build(BuildContext context) {
     final query = _query.trim().toLowerCase();
@@ -68,7 +38,6 @@ class _ProductListScreenState extends State<ProductListScreen> {
       }..removeWhere((value) => value.trim().isEmpty);
       return searchTargets.any((value) => value.toLowerCase().contains(query));
     }).toList();
-
 
     return Padding(
       padding: const EdgeInsets.all(12.0),
@@ -122,61 +91,6 @@ class _ProductListScreenState extends State<ProductListScreen> {
                   onEdit: widget.isAdmin
                       ? () async {
                           final result = await Navigator.push<ProductFormResult?>(
-
-
-    return Padding(
-      padding: const EdgeInsets.all(12.0),
-      child: Column(
-        children: [
-          TextField(
-            decoration: InputDecoration(
-              hintText: "Buscar producto...",
-              prefixIcon: const Icon(Icons.search),
-              border: OutlineInputBorder(borderRadius: BorderRadius.circular(12)),
-            ),
-            onChanged: (v) => setState(() => _query = v),
-          ),
-          const SizedBox(height: 15),
-          Expanded(
-            child: GridView.builder(
-              itemCount: filtered.length,
-              gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
-                crossAxisCount: 2,
-                crossAxisSpacing: 12,
-                mainAxisSpacing: 12,
-                childAspectRatio: 0.75,
-              ),
-              itemBuilder: (context, index) {
-                final product = filtered[index];
-                final originalIndex = widget.products.indexOf(product);
-
-                final bool showInventoryForThisCard =
-                    widget.isAdmin || (!widget.isAdmin && product.stock < 5);
-
-                return ProductCard(
-                  product: product,
-                  isAdmin: widget.isAdmin,
-                  showInventory: showInventoryForThisCard,
-                  enableBuy: !widget.isAdmin, // admin no compra
-                  onTap: () {
-                    Navigator.push(
-                      context,
-                      MaterialPageRoute(
-                        builder: (_) => ProductDetailScreen(
-                          product: product,
-                          isAdmin: widget.isAdmin,
-                          // Importante: NO hacemos pop aquí. Solo agregamos.
-                          onAddToCart: widget.isAdmin ? null : widget.onAddToCart,
-                        ),
-                      ),
-                    );
-                  },
-                  // Quick add (x1) desde tarjeta para cliente
-                  onAddToCart: widget.isAdmin ? null : () => widget.onAddToCart(product, 1),
-                  onEdit: widget.isAdmin
-                      ? () async {
-                          final updated = await Navigator.push<Product?>(
-
                             context,
                             MaterialPageRoute(
                               builder: (_) => EditProductScreen(product: product),
@@ -185,9 +99,6 @@ class _ProductListScreenState extends State<ProductListScreen> {
 
                           if (result != null && widget.onEditProduct != null) {
                             await widget.onEditProduct!(originalIndex, result);
-
-                          if (updated != null) {
-                            widget.onEditProduct(originalIndex, updated);
 
                             setState(() {});
                           }
@@ -202,14 +113,3 @@ class _ProductListScreenState extends State<ProductListScreen> {
     );
   }
 }
-
-                );
-              },
-            ),
-          ),
-        ],
-      ),
-    );
-  }
-}
-


### PR DESCRIPTION
## Summary
- remove duplicate imports and secondary ProductListScreen definition in product_list_screen.dart
- retain the version using Future-based edit callback and keep its build implementation intact

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d26525ca30832fa4707412d74fa6c5