### PR TITLE
Clean up main screen duplicates

### DIFF
--- a/lib/screens/main_screen.dart
+++ b/lib/screens/main_screen.dart
@@ -1,4 +1,3 @@
-
 import 'package:flutter/material.dart';
 
 import '../models/product.dart';
@@ -22,37 +21,6 @@ import 'login_screen.dart';
 
 // Services
 import '../services/api_client.dart';
-import '../services/auth_service.dart';
-import '../services/product_repository.dart';
-import '../services/order_repository.dart';
-
-class MainScreen extends StatefulWidget {
-  final Usuario user;
-
-  // Snapshots iniciales (para evitar pantallas vacías en el primer frame)
-  final List<Product> productsInitialSnapshot;
-
-import 'package:flutter/material.dart';
-
-import '../models/product.dart';
-import '../models/usuario.dart';
-import '../models/cart_item.dart';
-import '../models/order.dart';
-import '../models/order_item.dart';
-import '../models/order_status.dart';
-
-// Screens
-import 'product_list_screen.dart';
-import 'cart_screen.dart';
-import 'profile_screen.dart';
-import 'add_product_screen.dart';
-import 'admin_orders_screen.dart';
-import 'admin_analytics_screen.dart';
-import 'edit_profile_screen.dart';
-import 'order_history_screen.dart';
-import 'login_screen.dart';
-
-// Services
 import '../services/auth_service.dart';
 import '../services/product_repository.dart';
 import '../services/order_repository.dart';
@@ -285,44 +253,6 @@ class _MainScreenState extends State<MainScreen> {
     }
   }
 
-
-        action: SnackBarAction(
-          label: "Ver carrito",
-          onPressed: () {
-            // Cambia a la pestaña de carrito si es cliente
-            if (!isAdminEffective) {
-              setState(() => _selectedIndex = 1); // cliente: idx 1 = carrito
-            }
-          },
-        ),
-      ),
-    );
-  }
-
-  void _removeFromCart(int index) {
-    if (isAdminEffective) return;
-    setState(() => _cart.removeAt(index));
-  }
-
-  // ---------- CRUD de productos (dummy); si quisieras persistir, llama a repo y recarga ----------
-
-  Future<void> _createProduct(Product p) async {
-    // En dummy sólo agregamos a la lista local.
-    // Para persistir: await widget.productRepository.createProduct(p); await _loadProducts();
-    setState(() => _products.add(p));
-    ScaffoldMessenger.of(context).showSnackBar(
-      SnackBar(content: Text("Producto '${p.nombre}' agregado")),
-    );
-  }
-
-  Future<void> _editProduct(int index, Product updated) async {
-    // Para persistir: await widget.productRepository.updateProduct(updated); await _loadProducts();
-    setState(() => _products[index] = updated);
-    ScaffoldMessenger.of(context).showSnackBar(
-      SnackBar(content: Text("Producto '${updated.nombre}' actualizado")),
-    );
-  }
-
   // ---------- Pedidos ----------
 
   Future<void> _updateOrderStatus(String orderId, OrderStatus newStatus) async {
@@ -457,20 +387,17 @@ class _MainScreenState extends State<MainScreen> {
 
     // Volver al login reusando los mismos services
     Navigator.of(context).pushAndRemoveUntil(
-  MaterialPageRoute(
-    builder: (_) => LoginScreen(
-      authService: widget.authService,
-      productRepository: widget.productRepository,
-      orderRepository: widget.orderRepository,
-      ordersEnabled: widget.ordersEnabled,
-    ),
-  ),
-  (route) => false,
-);
-
+      MaterialPageRoute(
+        builder: (_) => LoginScreen(
+          authService: widget.authService,
+          productRepository: widget.productRepository,
+          orderRepository: widget.orderRepository,
+          ordersEnabled: widget.ordersEnabled,
+        ),
+      ),
+      (route) => false,
+    );
   }
-
-
 
   @override
   Widget build(BuildContext context) {
@@ -592,54 +519,11 @@ class _MainScreenState extends State<MainScreen> {
               backgroundColor: Colors.pink,
               onPressed: () async {
                 final result = await Navigator.push<ProductFormResult?>(
-
-
-    final List<BottomNavigationBarItem> items = isAdminEffective
-        ? const [
-            BottomNavigationBarItem(icon: Icon(Icons.store), label: "Productos"),
-            BottomNavigationBarItem(icon: Icon(Icons.receipt_long), label: "Pedidos"),
-            BottomNavigationBarItem(icon: Icon(Icons.bar_chart), label: "Estadísticas"),
-            BottomNavigationBarItem(icon: Icon(Icons.person), label: "Perfil"),
-          ]
-        : const [
-            BottomNavigationBarItem(icon: Icon(Icons.store), label: "Productos"),
-            BottomNavigationBarItem(icon: Icon(Icons.shopping_cart), label: "Carrito"),
-            BottomNavigationBarItem(icon: Icon(Icons.person), label: "Perfil"),
-          ];
-
-    if (_selectedIndex >= screens.length) {
-      _selectedIndex = 0;
-    }
-
-    final title = isAdminEffective
-        ? (["Productos", "Pedidos", "Estadísticas", "Perfil"][_selectedIndex])
-        : (["Productos", "Carrito", "Perfil"][_selectedIndex]);
-
-    return Scaffold(
-      appBar: AppBar(title: Text(title)),
-      body: IndexedStack(index: _selectedIndex, children: screens),
-      bottomNavigationBar: BottomNavigationBar(
-        currentIndex: _selectedIndex,
-        onTap: (i) {
-          if (i >= screens.length) return;
-          setState(() => _selectedIndex = i);
-        },
-        selectedItemColor: Colors.pink,
-        unselectedItemColor: Colors.grey,
-        items: items,
-      ),
-      floatingActionButton: isAdminEffective && _selectedIndex == 0
-          ? FloatingActionButton(
-              backgroundColor: Colors.pink,
-              onPressed: () async {
-                final result = await Navigator.push<Product?>(
-
                   context,
                   MaterialPageRoute(builder: (_) => const AddProductScreen()),
                 );
                 if (result != null) {
                   await _createProduct(result);
-
                 }
               },
               child: const Icon(Icons.add),
@@ -648,13 +532,3 @@ class _MainScreenState extends State<MainScreen> {
     );
   }
 }
-
-                }
-              },
-              child: const Icon(Icons.add),
-            )
-          : null,
-    );
-  }
-}
-


### PR DESCRIPTION
## Summary
- remove the redundant import block and duplicate MainScreen class definition
- keep the ProductFormResult-based admin product flow and clean up the floating action button logic

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d2652b4aa0832fac842901b5c3e5aa