### PR TITLE
Actualizar referencias de nombre de producto

### DIFF
--- a/lib/screens/main_screen.dart
+++ b/lib/screens/main_screen.dart
@@ -214,7 +214,7 @@ class _MainScreenState extends State<MainScreen> {
       await _loadProducts();
       if (!mounted) return;
       ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text("Producto '${created.name}' agregado")),
+        SnackBar(content: Text("Producto '${created.nombre}' agregado")),
       );
     } on ApiException catch (e) {
       if (!mounted) return;
@@ -238,7 +238,7 @@ class _MainScreenState extends State<MainScreen> {
       await _loadProducts();
       if (!mounted) return;
       ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text("Producto '${updated.name}' actualizado")),
+        SnackBar(content: Text("Producto '${updated.nombre}' actualizado")),
       );
     } on ApiException catch (e) {
       if (!mounted) return;


### PR DESCRIPTION
## Summary
- reemplazar el uso de created.name/updated.name por created.nombre/updated.nombre en el MainScreen
- asegurar que no queden referencias a product.name en la pantalla principal

## Testing
- flutter --version *(falla: comando no encontrado en el entorno)*

------
https://chatgpt.com/codex/tasks/task_e_68d26ee9f468832fbcf024f42c2ed040