### PR TITLE
Handle external absolute URLs in ApiClient

### DIFF
--- a/test/services/api_client_test.dart
+++ b/test/services/api_client_test.dart
@@ -33,6 +33,25 @@ void main() {
       final relative = client.resolveUriForTest('orders/123');
       expect(relative.toString(), 'http://localhost:3001/api/orders/123');
     });
+
+    test('mantiene solo los parámetros propios de URLs absolutas externas', () {
+      final client = ApiClient(
+        baseUrl: 'https://api.meysshop.com/base?lang=es&version=1',
+      );
+
+      final uri = client.resolveUriForTest(
+        'https://cdn.meysshop.com/assets/image.png?size=large&format=webp',
+        {'quality': 80, 'ignored': null},
+      );
+
+      expect(uri.scheme, 'https');
+      expect(uri.host, 'cdn.meysshop.com');
+      expect(uri.path, '/assets/image.png');
+      expect(
+        uri.queryParameters,
+        {'size': 'large', 'format': 'webp', 'quality': '80'},
+      );
+    });
   });
 
   group('reintentos automáticos', () {


### PR DESCRIPTION
## Summary
- adjust `_resolveUri` so that external absolute URLs no longer inherit base query parameters and only keep their own plus optional overrides
- preserve fragment handling while keeping existing relative path resolution behavior
- add a regression test ensuring external URLs keep only their query arguments

## Testing
- flutter test test/services/api_client_test.dart *(fails: flutter is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d27361834c832f95b3f07da57730c2