### PR TITLE
Fix catch clause syntax in API client

### DIFF
--- a/lib/services/api_client.dart
+++ b/lib/services/api_client.dart
@@ -460,7 +460,7 @@ class ApiClient {
 
       completer.complete();
       return true;
-    } catch (Object error, StackTrace stackTrace) {
+    } on Object catch (error, stackTrace) {
       if (error is ApiException &&
           (error.statusCode == 400 || error.statusCode == 401)) {
         clearTokens();


### PR DESCRIPTION
## Summary
- replace the token refresh catch clause with `on Object catch` to satisfy Dart analyzer expectations

## Testing
- `flutter analyze` *(fails: command not found: flutter)*

------
https://chatgpt.com/codex/tasks/task_e_68d277460178832f9c4f46bb87e68705