### PR TITLE
Remove redundant request URL mutations

### DIFF
--- a/lib/services/api_client.dart
+++ b/lib/services/api_client.dart
@@ -208,9 +208,6 @@ class ApiClient {
       if (request.method.toUpperCase() != upperMethod) {
         throw ArgumentError('Método del request no coincide con $upperMethod');
       }
-      if (request.url != resolvedUri) {
-        request.url = resolvedUri;
-      }
       request.headers.addAll(headers);
       return request;
     }
@@ -518,9 +515,6 @@ class _BaseRequestPayload {
     request.chunkedTransferEncoding = chunkedTransferEncoding;
     if (contentLength != null) {
       request.contentLength = contentLength!;
-    }
-    if (request.url != uri) {
-      request.url = uri;
     }
     request.headers.addAll(headers);
     return request;


### PR DESCRIPTION
## Summary
- remove the manual reassignment of the request URL when creating HTTP requests
- rely on the request factories receiving the resolved URI directly, keeping headers updates only

## Testing
- dart analyze *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d2774b987c832f9f0cabdad8114fd7