### PR TITLE
Remove deprecated encoding usage in multipart payload cloning

### DIFF
--- a/lib/services/api_client.dart
+++ b/lib/services/api_client.dart
@@ -526,7 +526,6 @@ class _BaseRequestPayload {
 
     if (request is http.MultipartRequest) {
       final fields = Map<String, String>.from(request.fields);
-      final encoding = request.encoding;
       final files = <_MultipartFilePayload>[];
       for (final file in request.files) {
         files.add(await _MultipartFilePayload.fromMultipartFile(file));
@@ -542,7 +541,6 @@ class _BaseRequestPayload {
         factory: (Uri uri) async {
           final clone = http.MultipartRequest(request.method, uri);
           clone.fields.addAll(fields);
-          clone.encoding = encoding;
           for (final file in files) {
             clone.files.add(file.toMultipartFile());
           }


### PR DESCRIPTION
## Summary
- stop copying the deprecated `encoding` property from multipart requests when cloning `_BaseRequestPayload`

## Testing
- `flutter analyze` *(fails: Flutter is not installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d280b3ecfc832fbe39b39dfd808855