### PR TITLE
Add register support to AuthService implementations

### DIFF
--- a/lib/services/auth_service.dart
+++ b/lib/services/auth_service.dart
@@ -5,6 +5,13 @@ abstract class AuthService {
   /// Inicia sesión y devuelve el usuario autenticado.
   Future<Usuario> login({required String email, required String password});
 
+  /// Crea una cuenta nueva en el sistema y devuelve el usuario resultante.
+  Future<Usuario> register({
+    required String nombre,
+    required String email,
+    required String password,
+  });
+
   /// Cierra sesión (en dummy no hace mucho, pero mantenemos la firma).
   Future<void> logout();
 

--- a/lib/services/auth_service_api.dart
+++ b/lib/services/auth_service_api.dart
@@ -9,6 +9,32 @@ class ApiAuthService implements AuthService {
   final ApiClient _client;
 
   @override
+  Future<Usuario> register({
+    required String nombre,
+    required String email,
+    required String password,
+  }) async {
+    final response = await _client.post(
+      '/api/auth/register',
+      body: {
+        'nombre': nombre,
+        'email': email,
+        'password': password,
+      },
+    );
+
+    if (response is! Map<String, dynamic>) {
+      throw ApiException(
+        500,
+        'Respuesta inválida del backend en register',
+        data: response,
+      );
+    }
+
+    return _usuarioFromJson(response);
+  }
+
+  @override
   Future<Usuario> login({required String email, required String password}) async {
     final response = await _client.post(
       '/api/auth/login',

--- a/test/services/auth_service_dummy_test.dart
+++ b/test/services/auth_service_dummy_test.dart
@@ -1,0 +1,71 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:meysshop_front1/models/usuario.dart';
+import 'package:meysshop_front1/services/auth_service_dummy.dart';
+
+void main() {
+  group('DummyAuthService', () {
+    late DummyAuthService service;
+
+    setUp(() {
+      service = DummyAuthService(
+        admin: Usuario(
+          id: 'admin-id',
+          nombre: 'Admin',
+          email: 'admin@example.com',
+          rol: 'admin',
+        ),
+        client: Usuario(
+          id: 'client-id',
+          nombre: 'Cliente',
+          email: 'cliente@example.com',
+          rol: 'cliente',
+        ),
+      );
+    });
+
+    test('permite login con usuarios sembrados', () async {
+      final adminUser = await service.login(
+        email: 'admin@example.com',
+        password: 'admin123',
+      );
+      expect(adminUser.rol, 'admin');
+
+      final clientUser = await service.login(
+        email: 'cliente@example.com',
+        password: 'cliente123',
+      );
+      expect(clientUser.rol, 'cliente');
+    });
+
+    test('register agrega nuevo usuario y permite login posterior', () async {
+      final nuevo = await service.register(
+        nombre: '  Nuevo Cliente  ',
+        email: 'nuevo@example.com ',
+        password: 'secreto123',
+      );
+
+      expect(nuevo.id, isNotEmpty);
+      expect(nuevo.email, 'nuevo@example.com');
+      expect(nuevo.nombre, 'Nuevo Cliente');
+      expect(nuevo.rol, 'cliente');
+
+      final loginUser = await service.login(
+        email: 'nuevo@example.com',
+        password: 'secreto123',
+      );
+      expect(loginUser.email, 'nuevo@example.com');
+      expect(loginUser.nombre, 'Nuevo Cliente');
+    });
+
+    test('no permite registrar un email duplicado', () async {
+      await expectLater(
+        service.register(
+          nombre: 'Otro usuario',
+          email: 'admin@example.com',
+          password: 'password',
+        ),
+        throwsA(isA<Exception>()),
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- add a register contract to `AuthService` and implement it for the API client
- allow the dummy auth service to create and authenticate in-memory accounts
- cover the dummy auth register flow with unit tests

## Testing
- flutter test *(fails: `flutter` command not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d2abed7424832fba495fbf23e97216