### PR TITLE
Add register screen and auth registration flow

### DIFF
--- a/lib/screens/login_screen.dart
+++ b/lib/screens/login_screen.dart
@@ -5,6 +5,7 @@ import '../models/order.dart';
 import '../models/order_item.dart';
 import '../models/order_status.dart';
 import 'main_screen.dart';
+import 'register_screen.dart';
 
 // Services
 import '../services/auth_service.dart';
@@ -84,6 +85,24 @@ class _LoginScreenState extends State<LoginScreen> {
     } finally {
       if (mounted) setState(() => _loading = false);
     }
+  }
+
+  Future<void> _openRegister() async {
+    FocusScope.of(context).unfocus();
+    final result = await Navigator.push<RegisterResult>(
+      context,
+      MaterialPageRoute(
+        builder: (_) => RegisterScreen(authService: widget.authService),
+      ),
+    );
+
+    if (!mounted || result == null) return;
+    _emailCtl.text = result.email;
+    ScaffoldMessenger.of(context).showSnackBar(
+      const SnackBar(
+        content: Text('Cuenta creada exitosamente. Inicia sesión con tus credenciales.'),
+      ),
+    );
   }
 
   List<Order> _seedOrdersIfNeeded(Usuario user, List<Product> products) {
@@ -206,6 +225,18 @@ class _LoginScreenState extends State<LoginScreen> {
                             )
                           : const Text("Iniciar sesión"),
                     ),
+                  ),
+
+                  const SizedBox(height: 12),
+                  Row(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: [
+                      const Text('¿No tienes cuenta?'),
+                      TextButton(
+                        onPressed: _loading ? null : _openRegister,
+                        child: const Text('Crear cuenta'),
+                      ),
+                    ],
                   ),
 
                   const SizedBox(height: 18),

--- a/lib/screens/register_screen.dart
+++ b/lib/screens/register_screen.dart
@@ -1,0 +1,179 @@
+import 'package:flutter/material.dart';
+
+import '../services/api_client.dart';
+import '../services/auth_service.dart';
+
+class RegisterResult {
+  const RegisterResult({required this.email});
+
+  final String email;
+}
+
+class RegisterScreen extends StatefulWidget {
+  const RegisterScreen({super.key, required this.authService});
+
+  final AuthService authService;
+
+  @override
+  State<RegisterScreen> createState() => _RegisterScreenState();
+}
+
+class _RegisterScreenState extends State<RegisterScreen> {
+  final _formKey = GlobalKey<FormState>();
+  final _nombreCtl = TextEditingController();
+  final _emailCtl = TextEditingController();
+  final _passwordCtl = TextEditingController();
+
+  bool _obscurePassword = true;
+  bool _loading = false;
+
+  @override
+  void dispose() {
+    _nombreCtl.dispose();
+    _emailCtl.dispose();
+    _passwordCtl.dispose();
+    super.dispose();
+  }
+
+  Future<void> _submit() async {
+    if (!_formKey.currentState!.validate()) return;
+
+    FocusScope.of(context).unfocus();
+    setState(() => _loading = true);
+
+    try {
+      await widget.authService.register(
+        nombre: _nombreCtl.text.trim(),
+        email: _emailCtl.text.trim(),
+        password: _passwordCtl.text,
+      );
+
+      if (!mounted) return;
+      Navigator.pop(
+        context,
+        RegisterResult(email: _emailCtl.text.trim()),
+      );
+    } on ApiException catch (e) {
+      if (!mounted) return;
+      _showMessage(e.message);
+    } catch (_) {
+      if (!mounted) return;
+      _showMessage('No se pudo crear la cuenta. Inténtalo nuevamente.');
+    } finally {
+      if (mounted) setState(() => _loading = false);
+    }
+  }
+
+  void _showMessage(String message) {
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(content: Text(message)),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('Crear cuenta')),
+      body: SafeArea(
+        child: SingleChildScrollView(
+          padding: const EdgeInsets.all(24),
+          child: Form(
+            key: _formKey,
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                Text(
+                  'Regístrate para comenzar',
+                  style: theme.textTheme.headlineSmall,
+                ),
+                const SizedBox(height: 20),
+                TextFormField(
+                  controller: _nombreCtl,
+                  textCapitalization: TextCapitalization.words,
+                  decoration: const InputDecoration(
+                    labelText: 'Nombre completo',
+                    prefixIcon: Icon(Icons.person),
+                  ),
+                  validator: (value) {
+                    if (value == null || value.trim().isEmpty) {
+                      return 'Ingresa tu nombre';
+                    }
+                    if (value.trim().length < 3) {
+                      return 'Nombre demasiado corto';
+                    }
+                    return null;
+                  },
+                ),
+                const SizedBox(height: 16),
+                TextFormField(
+                  controller: _emailCtl,
+                  decoration: const InputDecoration(
+                    labelText: 'Email',
+                    prefixIcon: Icon(Icons.email),
+                  ),
+                  keyboardType: TextInputType.emailAddress,
+                  validator: (value) {
+                    final trimmed = value?.trim() ?? '';
+                    if (trimmed.isEmpty) return 'Ingresa tu email';
+                    if (!trimmed.contains('@') || !trimmed.contains('.')) {
+                      return 'Email inválido';
+                    }
+                    return null;
+                  },
+                ),
+                const SizedBox(height: 16),
+                TextFormField(
+                  controller: _passwordCtl,
+                  obscureText: _obscurePassword,
+                  decoration: InputDecoration(
+                    labelText: 'Contraseña',
+                    prefixIcon: const Icon(Icons.lock),
+                    suffixIcon: IconButton(
+                      icon: Icon(
+                        _obscurePassword
+                            ? Icons.visibility_off
+                            : Icons.visibility,
+                      ),
+                      onPressed: () =>
+                          setState(() => _obscurePassword = !_obscurePassword),
+                    ),
+                  ),
+                  validator: (value) {
+                    if (value == null || value.isEmpty) {
+                      return 'Ingresa una contraseña';
+                    }
+                    if (value.length < 6) {
+                      return 'Mínimo 6 caracteres';
+                    }
+                    return null;
+                  },
+                ),
+                const SizedBox(height: 28),
+                ElevatedButton(
+                  onPressed: _loading ? null : _submit,
+                  child: _loading
+                      ? const SizedBox(
+                          height: 22,
+                          width: 22,
+                          child: CircularProgressIndicator(
+                            strokeWidth: 2,
+                            color: Colors.white,
+                          ),
+                        )
+                      : const Text('Registrarme'),
+                ),
+                const SizedBox(height: 12),
+                TextButton(
+                  onPressed: _loading ? null : () => Navigator.pop(context),
+                  child: const Text('Ya tengo una cuenta'),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/services/auth_service.dart
+++ b/lib/services/auth_service.dart
@@ -5,6 +5,13 @@ abstract class AuthService {
   /// Inicia sesión y devuelve el usuario autenticado.
   Future<Usuario> login({required String email, required String password});
 
+  /// Registra un nuevo usuario y devuelve su perfil básico.
+  Future<Usuario> register({
+    required String nombre,
+    required String email,
+    required String password,
+  });
+
   /// Cierra sesión (en dummy no hace mucho, pero mantenemos la firma).
   Future<void> logout();
 

--- a/lib/services/auth_service_api.dart
+++ b/lib/services/auth_service_api.dart
@@ -35,6 +35,45 @@ class ApiAuthService implements AuthService {
   }
 
   @override
+  Future<Usuario> register({
+    required String nombre,
+    required String email,
+    required String password,
+  }) async {
+    final response = await _client.post(
+      '/api/auth/register',
+      body: {
+        'nombre': nombre,
+        'email': email,
+        'password': password,
+      },
+    );
+
+    if (response is! Map<String, dynamic>) {
+      throw ApiException(
+        500,
+        'Respuesta inválida del backend en register',
+        data: response,
+      );
+    }
+
+    final id = response['id']?.toString();
+    final nombreResp = response['nombre']?.toString();
+    final emailResp = response['email']?.toString();
+
+    if (id == null || nombreResp == null || emailResp == null) {
+      throw ApiException(500, 'Registro sin datos válidos', data: response);
+    }
+
+    return Usuario(
+      id: id,
+      nombre: nombreResp,
+      email: emailResp,
+      rol: 'cliente',
+    );
+  }
+
+  @override
   Future<void> logout() async {
     final refresh = _client.refreshToken;
     try {

--- a/lib/services/auth_service_dummy.dart
+++ b/lib/services/auth_service_dummy.dart
@@ -3,27 +3,51 @@ import '../models/usuario.dart';
 import 'auth_service.dart';
 
 /// Implementación en memoria para DEMO.
-/// Valida contra dos usuarios y contraseñas fijas:
-/// - admin@example.com / admin123
-/// - cliente@example.com / cliente123
+/// Inicia con dos usuarios y permite registrar nuevos en runtime.
 class DummyAuthService implements AuthService {
-  final Usuario admin;
-  final Usuario client;
+  DummyAuthService({required Usuario admin, required Usuario client})
+      : _accounts = {
+          admin.email.toLowerCase(): _DummyAccount(admin, 'admin123'),
+          client.email.toLowerCase(): _DummyAccount(client, 'cliente123'),
+        };
 
-  DummyAuthService({required this.admin, required this.client});
+  final Map<String, _DummyAccount> _accounts;
+  int _nextId = 0;
 
   @override
   Future<Usuario> login({required String email, required String password}) async {
     await Future.delayed(const Duration(milliseconds: 250)); // micro feedback
 
-    if (email.toLowerCase() == admin.email.toLowerCase() && password == 'admin123') {
-      return admin;
-    }
-    if (email.toLowerCase() == client.email.toLowerCase() && password == 'cliente123') {
-      return client;
+    final account = _accounts[email.trim().toLowerCase()];
+    if (account != null && account.password == password) {
+      return account.user;
     }
 
     throw Exception('Credenciales inválidas');
+  }
+
+  @override
+  Future<Usuario> register({
+    required String nombre,
+    required String email,
+    required String password,
+  }) async {
+    await Future.delayed(const Duration(milliseconds: 300));
+
+    final key = email.trim().toLowerCase();
+    if (_accounts.containsKey(key)) {
+      throw Exception('Email ya registrado');
+    }
+
+    final user = Usuario(
+      id: 'u_reg_${++_nextId}',
+      nombre: nombre.trim(),
+      email: email.trim(),
+      rol: 'cliente',
+    );
+
+    _accounts[key] = _DummyAccount(user, password);
+    return user;
   }
 
   @override
@@ -37,4 +61,11 @@ class DummyAuthService implements AuthService {
     // No aplica en dummy.
     return null;
   }
+}
+
+class _DummyAccount {
+  _DummyAccount(this.user, this.password);
+
+  final Usuario user;
+  final String password;
 }


### PR DESCRIPTION
## Summary
- add a registration screen with form validation and error handling
- extend the authentication service contract/implementations with a register method
- wire the login screen to the new registration flow and show success feedback

## Testing
- Not run (Flutter/Dart tooling not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d2abee39c0832f9f64cf6d5057b2eb