### PR TITLE
Fix duplicate AuthService definition

### DIFF
--- a/lib/services/auth_service.dart
+++ b/lib/services/auth_service.dart
@@ -1,19 +1,11 @@
 import '../models/usuario.dart';
 
 /// Contrato de autenticación. La UI solo depende de esta interfaz.
-
-abstract class AuthService {
-  /// Inicia sesión y devuelve el usuario autenticado.
-  Future<Usuario> login({required String email, required String password});
-
-  /// Registra un nuevo usuario y devuelve su perfil básico.
-
 abstract class AuthService {
   /// Inicia sesión y devuelve el usuario autenticado.
   Future<Usuario> login({required String email, required String password});
 
   /// Crea una cuenta nueva en el sistema y devuelve el usuario resultante.
-
   Future<Usuario> register({
     required String nombre,
     required String email,
@@ -23,13 +15,6 @@ abstract class AuthService {
   /// Cierra sesión (en dummy no hace mucho, pero mantenemos la firma).
   Future<void> logout();
 
-
   /// Para escenarios con tokens. En dummy no se usa.
   Future<String?> refreshToken();
 }
-
-
-  /// Para escenarios con tokens. En dummy no se usa.
-  Future<String?> refreshToken();
-}
-


### PR DESCRIPTION
## Summary
- remove the duplicate `AuthService` interface definition so only one class remains
- keep the authentication method documentation together before the class declaration

## Testing
- flutter analyze *(fails: Flutter is not installed in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68d2b408bee8832fbdd5c54b7908e22e