### PR TITLE
Elimina duplicación de register en ApiAuthService

### DIFF
--- a/lib/services/auth_service_api.dart
+++ b/lib/services/auth_service_api.dart
@@ -31,7 +31,15 @@ class ApiAuthService implements AuthService {
       );
     }
 
-    return _usuarioFromJson(response);
+    final usuarioJson = response as Map<String, dynamic>;
+
+    if (usuarioJson['id'] == null ||
+        usuarioJson['nombre'] == null ||
+        usuarioJson['email'] == null) {
+      throw ApiException(500, 'Registro sin datos válidos', data: usuarioJson);
+    }
+
+    return _usuarioFromJson(usuarioJson);
   }
 
   @override
@@ -58,45 +66,6 @@ class ApiAuthService implements AuthService {
 
     _client.updateTokens(accessToken: access, refreshToken: refresh);
     return _usuarioFromJson(usuarioJson);
-  }
-
-  @override
-  Future<Usuario> register({
-    required String nombre,
-    required String email,
-    required String password,
-  }) async {
-    final response = await _client.post(
-      '/api/auth/register',
-      body: {
-        'nombre': nombre,
-        'email': email,
-        'password': password,
-      },
-    );
-
-    if (response is! Map<String, dynamic>) {
-      throw ApiException(
-        500,
-        'Respuesta inválida del backend en register',
-        data: response,
-      );
-    }
-
-    final id = response['id']?.toString();
-    final nombreResp = response['nombre']?.toString();
-    final emailResp = response['email']?.toString();
-
-    if (id == null || nombreResp == null || emailResp == null) {
-      throw ApiException(500, 'Registro sin datos válidos', data: response);
-    }
-
-    return Usuario(
-      id: id,
-      nombre: nombreResp,
-      email: emailResp,
-      rol: 'cliente',
-    );
   }
 
   @override


### PR DESCRIPTION
## Summary
- unifica la implementación de register en `ApiAuthService` para validar la respuesta del backend y mapear al modelo mediante `_usuarioFromJson`
- mantiene el inicio de sesión reutilizando el mismo mapeo privado

## Testing
- flutter analyze *(falla: el contenedor no tiene Flutter instalado)*

------
https://chatgpt.com/codex/tasks/task_e_68d2b40af144832fa1c875fc8e2d5030