### PR TITLE
Refactor dummy auth service duplicates

### DIFF
--- a/lib/services/auth_service_dummy.dart
+++ b/lib/services/auth_service_dummy.dart
@@ -1,20 +1,4 @@
 import 'dart:async';
-import '../models/usuario.dart';
-import 'auth_service.dart';
-
-/// Implementación en memoria para DEMO.
-/// Inicia con dos usuarios y permite registrar nuevos en runtime.
-class DummyAuthService implements AuthService {
-  DummyAuthService({required Usuario admin, required Usuario client})
-      : _accounts = {
-          admin.email.toLowerCase(): _DummyAccount(admin, 'admin123'),
-          client.email.toLowerCase(): _DummyAccount(client, 'cliente123'),
-        };
-
-  final Map<String, _DummyAccount> _accounts;
-  int _nextId = 0;
-
-import 'dart:async';
 
 import '../models/usuario.dart';
 import 'auth_service.dart';
@@ -22,13 +6,10 @@ import 'auth_service.dart';
 /// Implementación en memoria para DEMO.
 /// Valida contra usuarios precargados y los que se registren en la sesión actual.
 class DummyAuthService implements AuthService {
-  DummyAuthService({required this.admin, required this.client}) {
+  DummyAuthService({required Usuario admin, required Usuario client}) {
     _registerSeedUser(admin, 'admin123');
     _registerSeedUser(client, 'cliente123');
   }
-
-  final Usuario admin;
-  final Usuario client;
 
   final Map<String, _DummyAccount> _accounts = {};
   final Set<String> _usedIds = <String>{};
@@ -36,22 +17,13 @@ class DummyAuthService implements AuthService {
 
   @override
   Future<Usuario> login({required String email, required String password}) async {
-    await Future.delayed(const Duration(milliseconds: 250)); // micro feedback
-
-
-    final account = _accounts[email.trim().toLowerCase()];
-    if (account != null && account.password == password) {
-      return account.user;
-    }
-
-    throw Exception('Credenciales inválidas');
+    await Future.delayed(const Duration(milliseconds: 250));
 
     final account = _accounts[_normalizeEmail(email)];
     if (account == null || account.password != password) {
       throw Exception('Credenciales inválidas');
     }
     return account.usuario;
-
   }
 
   @override
@@ -60,66 +32,35 @@ class DummyAuthService implements AuthService {
     required String email,
     required String password,
   }) async {
-
     await Future.delayed(const Duration(milliseconds: 300));
 
-    final key = email.trim().toLowerCase();
-
-    await Future.delayed(const Duration(milliseconds: 250));
-
-    final normalizedEmail = email.trim();
-    final key = _normalizeEmail(normalizedEmail);
-
-    if (_accounts.containsKey(key)) {
+    final normalizedEmail = _normalizeEmail(email);
+    if (_accounts.containsKey(normalizedEmail)) {
       throw Exception('Email ya registrado');
     }
 
-
-    final user = Usuario(
-      id: 'u_reg_${++_nextId}',
+    final usuario = Usuario(
+      id: _generateId(),
       nombre: nombre.trim(),
       email: email.trim(),
       rol: 'cliente',
     );
 
-    _accounts[key] = _DummyAccount(user, password);
-    return user;
-
-    final usuario = Usuario(
-      id: _generateId(),
-      nombre: nombre.trim(),
-      email: normalizedEmail,
-      rol: 'cliente',
-    );
-
-    _accounts[key] = _DummyAccount(usuario: usuario, password: password);
+    _accounts[normalizedEmail] =
+        _DummyAccount(usuario: usuario, password: password);
     return usuario;
-
   }
 
   @override
   Future<void> logout() async {
-    
     await Future.delayed(const Duration(milliseconds: 120));
   }
 
-
   @override
-
-  @override
-
   Future<String?> refreshToken() async {
     // No aplica en dummy.
     return null;
   }
-
-}
-
-class _DummyAccount {
-  _DummyAccount(this.user, this.password);
-
-  final Usuario user;
-
 
   void _registerSeedUser(Usuario usuario, String password) {
     final key = _normalizeEmail(usuario.email);
@@ -141,9 +82,8 @@ class _DummyAccount {
 }
 
 class _DummyAccount {
-  _DummyAccount({required this.usuario, required this.password});
+  const _DummyAccount({required this.usuario, required this.password});
 
   final Usuario usuario;
-
   final String password;
 }


### PR DESCRIPTION
## Summary
- consolidate the dummy auth service into a single implementation and ensure login/register/logout/refresh methods are consistent
- keep one `_DummyAccount` model and reuse shared helpers for seeding users, normalizing correos and generating IDs

## Testing
- `flutter analyze` *(fails: Flutter SDK not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d2b40e41b0832f85b5a2f830696014