### PR TITLE
Expose productos routes

### DIFF
--- a/routes/index.js
+++ b/routes/index.js
@@ -4,6 +4,7 @@ const router = express.Router();
 // Rutas de módulos
 const authRoutes = require('./auth.routes');
 const clientesRoutes = require('./cliente.routes'); // si aún no la tienes, la pasamos después
+const productosRoutes = require('./producto.routes');
 const profileRoutes = require('./profile.routes');
 
 // Healthcheck simple (opcional)
@@ -12,6 +13,7 @@ router.get('/health', (_req, res) => res.json({ ok: true, ts: Date.now() }));
 // Montaje con prefijo /api
 router.use('/api/auth', authRoutes);
 router.use('/api/clientes', clientesRoutes);
+router.use('/api/productos', productosRoutes);
 router.use('/api/profile', profileRoutes);
 
 module.exports = router;

--- a/routes/producto.routes.js
+++ b/routes/producto.routes.js
@@ -1,0 +1,45 @@
+const express = require('express');
+const adapter = require('../adapters/clienteAdapter');
+const validate = require('../middleware/validate');
+const { requiereAuth, requiereAdmin } = require('../middleware/authJwt');
+const { handleSingle } = require('../middleware/uploadProductImage');
+const {
+  crearClienteRules,
+  actualizarClienteRules,
+  eliminarClienteRules,
+} = require('../middleware/validaciones/cliente');
+
+const r = express.Router();
+
+r.get('/', adapter.listar);
+
+r.post(
+  '/',
+  requiereAuth,
+  requiereAdmin,
+  handleSingle('imagen'),
+  crearClienteRules,
+  validate,
+  adapter.crear,
+);
+
+r.put(
+  '/:id',
+  requiereAuth,
+  requiereAdmin,
+  handleSingle('imagen'),
+  actualizarClienteRules,
+  validate,
+  adapter.actualizar,
+);
+
+r.delete(
+  '/:id',
+  requiereAuth,
+  requiereAdmin,
+  eliminarClienteRules,
+  validate,
+  adapter.eliminar,
+);
+
+module.exports = r;


### PR DESCRIPTION
## Summary
- add an /api/productos router that reuses the existing cliente adapter and middleware
- wire the new productos router into the API index so the frontend can reach /api/productos endpoints

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68cbc1c11ab8832fb1d7b526ea105005