### PR TITLE
feat: separar productos de clientes

### DIFF
--- a/adapters/productoAdapter.js
+++ b/adapters/productoAdapter.js
@@ -1,0 +1,42 @@
+const { validationResult } = require('express-validator');
+const ctrl = require('../controllers/productoController');
+
+module.exports = {
+  listar: async (req, res) => {
+    try {
+      await ctrl.listar(req, res);
+    } catch (e) {
+      res.status(500).json({ error: e.message });
+    }
+  },
+
+  crear: async (req, res) => {
+    try {
+      const errors = validationResult(req);
+      if (!errors.isEmpty()) return res.status(400).json({ error: errors.array()[0].msg });
+      await ctrl.crear(req, res);
+    } catch (e) {
+      res.status(400).json({ error: e.message });
+    }
+  },
+
+  actualizar: async (req, res) => {
+    try {
+      const errors = validationResult(req);
+      if (!errors.isEmpty()) return res.status(400).json({ error: errors.array()[0].msg });
+      await ctrl.actualizar(req, res);
+    } catch (e) {
+      res.status(400).json({ error: e.message });
+    }
+  },
+
+  eliminar: async (req, res) => {
+    try {
+      const errors = validationResult(req);
+      if (!errors.isEmpty()) return res.status(400).json({ error: errors.array()[0].msg });
+      await ctrl.eliminar(req, res);
+    } catch (e) {
+      res.status(400).json({ error: e.message });
+    }
+  }
+};

--- a/controllers/clienteController.js
+++ b/controllers/clienteController.js
@@ -1,14 +1,8 @@
-const fs = require('fs');
-const path = require('path');
 const clienteRepo = require('../repositories/clienteRepository');
 
-const IMAGE_RELATIVE_BASE = path.posix.join('uploads', 'products');
-
 const requiredText = (value, fieldName) => {
-  if (typeof value !== 'string') {
-    throw new Error(`${fieldName} requerido`);
-  }
-  const trimmed = value.trim();
+  const val = value ?? '';
+  const trimmed = val.toString().trim();
   if (!trimmed) {
     throw new Error(`${fieldName} requerido`);
   }
@@ -16,145 +10,57 @@ const requiredText = (value, fieldName) => {
 };
 
 const optionalText = (value, fallback = null) => {
-  if (value === undefined || value === null) {
-    return fallback ?? null;
-  }
+  if (value === undefined) return fallback;
+  if (value === null) return null;
   const trimmed = value.toString().trim();
-  if (!trimmed) {
-    return fallback ?? null;
-  }
+  if (!trimmed) return null;
   return trimmed;
 };
 
-const parsePrice = (value, fallback = null) => {
-  if (value === undefined || value === null || value === '') {
-    return fallback;
-  }
-  const parsed = Number.parseFloat(value);
-  if (!Number.isFinite(parsed) || parsed <= 0) {
-    throw new Error('Precio inválido');
-  }
-  return parsed;
+const normalizeEmail = (value, fallback = null) => {
+  if (value === undefined) return fallback;
+  if (value === null) return null;
+  const trimmed = value.toString().trim();
+  if (!trimmed) return null;
+  return trimmed.toLowerCase();
 };
 
-const parseCantidad = (value, fallback = null) => {
-  if (value === undefined || value === null || value === '') {
-    return fallback;
-  }
-  const parsed = Number.parseInt(value, 10);
-  if (!Number.isFinite(parsed) || parsed < 0) {
-    throw new Error('Cantidad inválida');
-  }
-  return parsed;
-};
-
-const toRelativeImagePath = (file) => {
-  if (!file) return null;
-  const filename = file.filename || path.basename(file.path);
-  return path.posix.join(IMAGE_RELATIVE_BASE, filename);
-};
-
-const toAbsolutePath = (relativePath) => {
-  if (!relativePath) return null;
-  const safe = relativePath.replace(/\\/g, '/');
-  return path.join(__dirname, '..', safe.split('/').join(path.sep));
-};
-
-const removeImage = (relativePath) => {
-  const absolute = toAbsolutePath(relativePath);
-  if (!absolute) return;
-  fs.promises.unlink(absolute).catch(() => {});
-};
-
-const buildPayload = (body, { existing = null, imagePath = null } = {}) => {
-  if (!existing) {
-    const price = parsePrice(body.price ?? body.precio, null);
-    const cantidad = parseCantidad(body.cantidad ?? body.stock, null);
-    if (price == null) throw new Error('Precio inválido');
-    if (cantidad == null) throw new Error('Cantidad inválida');
-
-    return {
-      nombre: requiredText(body.nombre, 'Nombre'),
-      apellido: requiredText(body.apellido, 'Apellido'),
-      email: optionalText(body.email, null),
-      telefono: optionalText(body.telefono, null),
-      direccion: optionalText(body.direccion, null),
-      estado: optionalText(body.estado, 'Activo') || 'Activo',
-      price,
-      cantidad,
-      imagen: imagePath,
-    };
-  }
-
-  const payload = {
-    nombre: optionalText(body.nombre, existing.nombre),
-    apellido: optionalText(body.apellido, existing.apellido),
-    email: optionalText(body.email, existing.email ?? null),
-    telefono: optionalText(body.telefono, existing.telefono ?? null),
-    direccion: optionalText(body.direccion, existing.direccion ?? null),
-    estado: optionalText(body.estado, existing.estado || 'Activo') || existing.estado || 'Activo',
-    price: parsePrice(body.price ?? body.precio, existing.price),
-    cantidad: parseCantidad(body.cantidad ?? body.stock, existing.cantidad),
-  };
-
-  if (imagePath) {
-    payload.imagen = imagePath;
-  }
-
-  return payload;
-};
-
-const mapProductResponse = (req, data) => {
-  if (!data) return null;
-  const { imagen, ...rest } = data;
-  const normalized = imagen ? imagen.replace(/\\/g, '/') : '';
-  return {
-    ...rest,
-    imageUrl: normalized ? `${req.protocol}://${req.get('host')}/${normalized}` : '',
-  };
-};
-
-// GET /api/clientes?q=texto
 const listar = async (req, res) => {
   try {
-    const q = typeof req.query.q === 'string' && req.query.q.trim() !== '' ? req.query.q.trim() : null;
+    const rawQuery = typeof req.query.q === 'string' ? req.query.q : null;
+    const q = rawQuery && rawQuery.trim() !== '' ? rawQuery.trim() : null;
     const items = await clienteRepo.listar({ q });
-    res.json(items.map((item) => mapProductResponse(req, item)));
+    res.json(items);
   } catch (e) {
     res.status(500).json({ error: e.message });
   }
 };
 
-// POST /api/clientes
 const crear = async (req, res) => {
-  let newImagePath = null;
   try {
-    if (!req.file) {
-      return res.status(400).json({ error: 'Imagen requerida (JPG o PNG)' });
-    }
-
-    newImagePath = toRelativeImagePath(req.file);
-    const payload = buildPayload(req.body, { imagePath: newImagePath });
+    const payload = {
+      nombre: requiredText(req.body?.nombre, 'Nombre'),
+      apellido: requiredText(req.body?.apellido, 'Apellido'),
+      email: normalizeEmail(req.body?.email, null),
+      telefono: optionalText(req.body?.telefono, null),
+      direccion: optionalText(req.body?.direccion, null),
+    };
 
     if (payload.email) {
       const yaExiste = await clienteRepo.existeEmail(payload.email);
       if (yaExiste) {
-        removeImage(newImagePath);
         return res.status(409).json({ error: 'Email ya registrado' });
       }
     }
 
     const item = await clienteRepo.crear(payload);
-    res.status(201).json(mapProductResponse(req, item));
+    res.status(201).json(item);
   } catch (e) {
-    if (newImagePath) removeImage(newImagePath);
     res.status(400).json({ error: e.message });
   }
 };
 
-// PUT /api/clientes/:id
 const actualizar = async (req, res) => {
-  let newImagePath = null;
   try {
     const id = Number(req.params.id);
     if (Number.isNaN(id) || id <= 0) return res.status(400).json({ error: 'ID inválido' });
@@ -162,49 +68,51 @@ const actualizar = async (req, res) => {
     const actual = await clienteRepo.buscarPorId(id);
     if (!actual) return res.status(404).json({ error: 'No encontrado' });
 
-    if (req.file) {
-      newImagePath = toRelativeImagePath(req.file);
+    const payload = {};
+
+    if (req.body?.nombre !== undefined) {
+      payload.nombre = requiredText(req.body.nombre, 'Nombre');
     }
-
-    const payload = buildPayload(req.body, { existing: actual, imagePath: newImagePath });
-
-    if (payload.email) {
-      const yaExiste = await clienteRepo.existeEmail(payload.email, { excluirId: id });
-      if (yaExiste) {
-        if (newImagePath) removeImage(newImagePath);
-        return res.status(409).json({ error: 'Email ya registrado' });
+    if (req.body?.apellido !== undefined) {
+      payload.apellido = requiredText(req.body.apellido, 'Apellido');
+    }
+    if (req.body?.telefono !== undefined) {
+      payload.telefono = optionalText(req.body.telefono, null);
+    }
+    if (req.body?.direccion !== undefined) {
+      payload.direccion = optionalText(req.body.direccion, null);
+    }
+    if (req.body?.email !== undefined) {
+      payload.email = normalizeEmail(req.body.email, null);
+      if (payload.email) {
+        const yaExiste = await clienteRepo.existeEmail(payload.email, { excluirId: id });
+        if (yaExiste) {
+          return res.status(409).json({ error: 'Email ya registrado' });
+        }
       }
     }
 
+    if (Object.keys(payload).length === 0) {
+      return res.json(actual);
+    }
+
     const actualizado = await clienteRepo.actualizar(id, payload);
-    if (!actualizado) {
-      if (newImagePath) removeImage(newImagePath);
-      return res.status(404).json({ error: 'No encontrado' });
-    }
+    if (!actualizado) return res.status(404).json({ error: 'No encontrado' });
 
-    if (newImagePath && actual.imagen && actual.imagen !== newImagePath) {
-      removeImage(actual.imagen);
-    }
-
-    res.json(mapProductResponse(req, actualizado));
+    res.json(actualizado);
   } catch (e) {
-    if (newImagePath) removeImage(newImagePath);
     res.status(400).json({ error: e.message });
   }
 };
 
-// DELETE /api/clientes/:id
 const eliminar = async (req, res) => {
   try {
     const id = Number(req.params.id);
     if (Number.isNaN(id) || id <= 0) return res.status(400).json({ error: 'ID inválido' });
 
-    const existing = await clienteRepo.buscarPorId(id);
     const ok = await clienteRepo.eliminar(id);
     if (!ok) return res.status(404).json({ error: 'No encontrado' });
-    if (existing?.imagen) {
-      removeImage(existing.imagen);
-    }
+
     res.json({ ok: true });
   } catch (e) {
     res.status(400).json({ error: e.message });

--- a/controllers/productoController.js
+++ b/controllers/productoController.js
@@ -1,0 +1,229 @@
+const fs = require('fs');
+const path = require('path');
+const productoRepo = require('../repositories/productoRepository');
+
+const IMAGE_RELATIVE_BASE = path.posix.join('uploads', 'products');
+
+const requiredText = (value, fieldName) => {
+  const val = value ?? '';
+  const trimmed = val.toString().trim();
+  if (!trimmed) {
+    throw new Error(`${fieldName} requerido`);
+  }
+  return trimmed;
+};
+
+const optionalText = (value, fallback = null) => {
+  if (value === undefined || value === null) {
+    return fallback ?? null;
+  }
+  const trimmed = value.toString().trim();
+  if (!trimmed) {
+    return fallback ?? null;
+  }
+  return trimmed;
+};
+
+const parsePrice = (value, fallback = null) => {
+  if (value === undefined || value === null || value === '') {
+    return fallback;
+  }
+  const parsed = Number.parseFloat(value);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    throw new Error('Precio inválido');
+  }
+  return parsed;
+};
+
+const parseStock = (value, fallback = null) => {
+  if (value === undefined || value === null || value === '') {
+    return fallback;
+  }
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isFinite(parsed) || parsed < 0) {
+    throw new Error('Stock inválido');
+  }
+  return parsed;
+};
+
+const pickFirst = (...values) => values.find((value) => value !== undefined && value !== null);
+
+const toRelativeImagePath = (file) => {
+  if (!file) return null;
+  const filename = file.filename || path.basename(file.path);
+  return path.posix.join(IMAGE_RELATIVE_BASE, filename);
+};
+
+const isRemotePath = (value) => typeof value === 'string' && /^https?:\/\//i.test(value.trim());
+
+const toAbsolutePath = (relativePath) => {
+  if (!relativePath || isRemotePath(relativePath)) return null;
+  const safe = relativePath.replace(/\\/g, '/');
+  return path.join(__dirname, '..', safe.split('/').join(path.sep));
+};
+
+const removeImage = (relativePath) => {
+  const absolute = toAbsolutePath(relativePath);
+  if (!absolute) return;
+  fs.promises.unlink(absolute).catch(() => {});
+};
+
+const mapIncomingImage = (body) => {
+  if (!body) return undefined;
+  const raw = pickFirst(body.imagenUrl, body.imageUrl, body.imagen, body.imagen_url);
+  if (raw === undefined) return undefined;
+  if (raw === null) return '';
+  const trimmed = raw.toString().trim();
+  return trimmed;
+};
+
+const buildPayload = (body, { existing = null, imagePath = null, remoteImage = undefined } = {}) => {
+  const nombreRaw = pickFirst(body?.nombre, body?.name);
+  const descripcionRaw = pickFirst(body?.descripcion, body?.description);
+  const categoriaRaw = pickFirst(body?.categoria, body?.category);
+  const precioRaw = pickFirst(body?.precio, body?.price);
+  const stockRaw = pickFirst(body?.stock, body?.cantidad);
+
+  if (!existing) {
+    const precio = parsePrice(precioRaw, null);
+    const stock = parseStock(stockRaw, null);
+    if (precio == null) throw new Error('Precio inválido');
+    if (stock == null) throw new Error('Stock inválido');
+
+    const payload = {
+      nombre: requiredText(nombreRaw, 'Nombre'),
+      descripcion: requiredText(descripcionRaw, 'Descripción'),
+      categoria: requiredText(categoriaRaw, 'Categoría'),
+      precio,
+      stock,
+      estado: optionalText(body?.estado, 'Activo') || 'Activo'
+    };
+
+    if (imagePath) {
+      payload.imagen = imagePath;
+    } else if (remoteImage !== undefined) {
+      payload.imagen = remoteImage ? remoteImage : null;
+    }
+
+    return payload;
+  }
+
+  const payload = {
+    nombre: optionalText(nombreRaw, existing.nombre),
+    descripcion: optionalText(descripcionRaw, existing.descripcion),
+    categoria: optionalText(categoriaRaw, existing.categoria),
+    precio: parsePrice(precioRaw, existing.precio),
+    stock: parseStock(stockRaw, existing.stock),
+    estado: optionalText(body?.estado, existing.estado || 'Activo') || existing.estado || 'Activo'
+  };
+
+  if (imagePath) {
+    payload.imagen = imagePath;
+  } else if (remoteImage !== undefined) {
+    payload.imagen = remoteImage ? remoteImage : null;
+  }
+
+  return payload;
+};
+
+const mapProductResponse = (req, data) => {
+  if (!data) return null;
+  const { imagen, ...rest } = data;
+  let imagenUrl = '';
+  if (imagen) {
+    if (isRemotePath(imagen)) {
+      imagenUrl = imagen;
+    } else {
+      const normalized = imagen.replace(/\\/g, '/');
+      imagenUrl = `${req.protocol}://${req.get('host')}/${normalized}`;
+    }
+  }
+  return { ...rest, imagen, imagenUrl };
+};
+
+const listar = async (req, res) => {
+  try {
+    const rawQuery = pickFirst(req.query?.q, req.query?.search);
+    const q = typeof rawQuery === 'string' && rawQuery.trim() !== '' ? rawQuery.trim() : null;
+    const items = await productoRepo.listar({ q });
+    res.json(items.map((item) => mapProductResponse(req, item)));
+  } catch (e) {
+    res.status(500).json({ error: e.message });
+  }
+};
+
+const crear = async (req, res) => {
+  let newImagePath = null;
+  try {
+    const remoteImage = mapIncomingImage(req.body);
+    if (!req.file && (!remoteImage || remoteImage.trim() === '')) {
+      return res.status(400).json({ error: 'Imagen requerida (archivo JPG/PNG o URL)' });
+    }
+
+    if (req.file) {
+      newImagePath = toRelativeImagePath(req.file);
+    }
+
+    const payload = buildPayload(req.body, { imagePath: newImagePath, remoteImage });
+    const item = await productoRepo.crear(payload);
+    res.status(201).json(mapProductResponse(req, item));
+  } catch (e) {
+    if (newImagePath) removeImage(newImagePath);
+    res.status(400).json({ error: e.message });
+  }
+};
+
+const actualizar = async (req, res) => {
+  let newImagePath = null;
+  try {
+    const id = Number(req.params.id);
+    if (Number.isNaN(id) || id <= 0) return res.status(400).json({ error: 'ID inválido' });
+
+    const actual = await productoRepo.buscarPorId(id);
+    if (!actual) return res.status(404).json({ error: 'No encontrado' });
+
+    const remoteImage = mapIncomingImage(req.body);
+    if (req.file) {
+      newImagePath = toRelativeImagePath(req.file);
+    }
+
+    const payload = buildPayload(req.body, { existing: actual, imagePath: newImagePath, remoteImage });
+    const actualizado = await productoRepo.actualizar(id, payload);
+    if (!actualizado) {
+      if (newImagePath) removeImage(newImagePath);
+      return res.status(404).json({ error: 'No encontrado' });
+    }
+
+    if (newImagePath && actual.imagen && actual.imagen !== newImagePath) {
+      removeImage(actual.imagen);
+    } else if (remoteImage !== undefined && actual.imagen && actual.imagen !== payload.imagen && !isRemotePath(actual.imagen)) {
+      removeImage(actual.imagen);
+    }
+
+    res.json(mapProductResponse(req, actualizado));
+  } catch (e) {
+    if (newImagePath) removeImage(newImagePath);
+    res.status(400).json({ error: e.message });
+  }
+};
+
+const eliminar = async (req, res) => {
+  try {
+    const id = Number(req.params.id);
+    if (Number.isNaN(id) || id <= 0) return res.status(400).json({ error: 'ID inválido' });
+
+    const existing = await productoRepo.buscarPorId(id);
+    const ok = await productoRepo.eliminar(id);
+    if (!ok) return res.status(404).json({ error: 'No encontrado' });
+
+    if (existing?.imagen && !isRemotePath(existing.imagen)) {
+      removeImage(existing.imagen);
+    }
+
+    res.json({ ok: true });
+  } catch (e) {
+    res.status(400).json({ error: e.message });
+  }
+};
+
+module.exports = { listar, crear, actualizar, eliminar };

--- a/middleware/validaciones/cliente.js
+++ b/middleware/validaciones/cliente.js
@@ -2,23 +2,21 @@ const { body, param } = require('express-validator');
 
 // Crear cliente
 const crearClienteRules = [
-  body('nombre').isString().isLength({ min: 2 }).withMessage('Nombre requerido (mín 2)'),
-  body('apellido').isString().isLength({ min: 2 }).withMessage('Apellido requerido (mín 2)'),
-  body('email').optional({ nullable: true }).isEmail().withMessage('Email inválido'),
-  body('telefono').optional({ nullable: true }).isString(),
-  body('direccion').optional({ nullable: true }).isString(),
-  body('price').isFloat({ gt: 0 }).withMessage('Precio inválido'),
-  body('cantidad').isInt({ min: 0 }).withMessage('Cantidad inválida'),
-  body('estado').optional({ nullable: true }).isString().isLength({ min: 1, max: 50 }),
+  body('nombre').isString().trim().isLength({ min: 2 }).withMessage('Nombre requerido (mín 2)'),
+  body('apellido').isString().trim().isLength({ min: 2 }).withMessage('Apellido requerido (mín 2)'),
+  body('email').optional({ nullable: true, checkFalsy: true }).isEmail().withMessage('Email inválido'),
+  body('telefono').optional({ nullable: true, checkFalsy: true }).isString().isLength({ min: 3 }).withMessage('Teléfono inválido'),
+  body('direccion').optional({ nullable: true, checkFalsy: true }).isString().isLength({ min: 3 }).withMessage('Dirección inválida'),
 ];
 
 // Actualizar cliente
 const actualizarClienteRules = [
   param('id').isInt({ min: 1 }).withMessage('ID inválido'),
-  body('email').optional({ nullable: true }).isEmail().withMessage('Email inválido'),
-  body('price').optional({ nullable: true }).isFloat({ gt: 0 }).withMessage('Precio inválido'),
-  body('cantidad').optional({ nullable: true }).isInt({ min: 0 }).withMessage('Cantidad inválida'),
-  body('estado').optional({ nullable: true }).isString().isLength({ min: 1, max: 50 }),
+  body('nombre').optional({ nullable: true, checkFalsy: true }).isString().trim().isLength({ min: 2 }).withMessage('Nombre requerido (mín 2)'),
+  body('apellido').optional({ nullable: true, checkFalsy: true }).isString().trim().isLength({ min: 2 }).withMessage('Apellido requerido (mín 2)'),
+  body('email').optional({ nullable: true, checkFalsy: true }).isEmail().withMessage('Email inválido'),
+  body('telefono').optional({ nullable: true, checkFalsy: true }).isString().isLength({ min: 3 }).withMessage('Teléfono inválido'),
+  body('direccion').optional({ nullable: true, checkFalsy: true }).isString().isLength({ min: 3 }).withMessage('Dirección inválida'),
 ];
 
 // Eliminar cliente

--- a/middleware/validaciones/producto.js
+++ b/middleware/validaciones/producto.js
@@ -1,0 +1,81 @@
+const { body, param } = require('express-validator');
+
+const getPrecioValor = (req) => (req.body.precio !== undefined ? req.body.precio : req.body.price);
+const getStockValor = (req) => (req.body.stock !== undefined ? req.body.stock : req.body.cantidad);
+
+const validarPrecioRequerido = (value, { req }) => {
+  const raw = getPrecioValor(req);
+  if (raw === undefined || raw === null || raw === '') {
+    throw new Error('Precio inválido');
+  }
+  const parsed = Number.parseFloat(raw);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    throw new Error('Precio inválido');
+  }
+  return true;
+};
+
+const validarPrecioOpcional = (value, { req }) => {
+  const provided = req.body.precio !== undefined || req.body.price !== undefined;
+  if (!provided) return true;
+  const raw = getPrecioValor(req);
+  if (raw === undefined || raw === null || raw === '') {
+    throw new Error('Precio inválido');
+  }
+  const parsed = Number.parseFloat(raw);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    throw new Error('Precio inválido');
+  }
+  return true;
+};
+
+const validarStockRequerido = (value, { req }) => {
+  const raw = getStockValor(req);
+  if (raw === undefined || raw === null || raw === '') {
+    throw new Error('Stock inválido');
+  }
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isFinite(parsed) || parsed < 0) {
+    throw new Error('Stock inválido');
+  }
+  return true;
+};
+
+const validarStockOpcional = (value, { req }) => {
+  const provided = req.body.stock !== undefined || req.body.cantidad !== undefined;
+  if (!provided) return true;
+  const raw = getStockValor(req);
+  if (raw === undefined || raw === null || raw === '') {
+    throw new Error('Stock inválido');
+  }
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isFinite(parsed) || parsed < 0) {
+    throw new Error('Stock inválido');
+  }
+  return true;
+};
+
+const crearProductoRules = [
+  body('nombre').isString().trim().isLength({ min: 2 }).withMessage('Nombre requerido (mín 2)'),
+  body('descripcion').isString().trim().isLength({ min: 5 }).withMessage('Descripción requerida (mín 5)'),
+  body('categoria').isString().trim().isLength({ min: 2 }).withMessage('Categoría requerida (mín 2)'),
+  body('precio').custom(validarPrecioRequerido),
+  body('stock').custom(validarStockRequerido),
+  body('estado').optional({ nullable: true }).isString().isLength({ min: 1, max: 50 })
+];
+
+const actualizarProductoRules = [
+  param('id').isInt({ min: 1 }).withMessage('ID inválido'),
+  body('nombre').optional({ nullable: true }).isString().trim().isLength({ min: 2 }).withMessage('Nombre requerido (mín 2)'),
+  body('descripcion').optional({ nullable: true }).isString().trim().isLength({ min: 5 }).withMessage('Descripción inválida (mín 5)'),
+  body('categoria').optional({ nullable: true }).isString().trim().isLength({ min: 2 }).withMessage('Categoría inválida (mín 2)'),
+  body('precio').custom(validarPrecioOpcional),
+  body('stock').custom(validarStockOpcional),
+  body('estado').optional({ nullable: true }).isString().isLength({ min: 1, max: 50 })
+];
+
+const eliminarProductoRules = [
+  param('id').isInt({ min: 1 }).withMessage('ID inválido')
+];
+
+module.exports = { crearProductoRules, actualizarProductoRules, eliminarProductoRules };

--- a/migrations/20250917030000-create-producto.js
+++ b/migrations/20250917030000-create-producto.js
@@ -1,0 +1,95 @@
+'use strict';
+
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    const transaction = await queryInterface.sequelize.transaction();
+    try {
+      await queryInterface.createTable('Productos', {
+        id: {
+          allowNull: false,
+          autoIncrement: true,
+          primaryKey: true,
+          type: Sequelize.INTEGER
+        },
+        nombre: {
+          type: Sequelize.STRING(150),
+          allowNull: false
+        },
+        descripcion: {
+          type: Sequelize.TEXT,
+          allowNull: false
+        },
+        categoria: {
+          type: Sequelize.STRING(120),
+          allowNull: false,
+          defaultValue: 'General'
+        },
+        precio: {
+          type: Sequelize.DECIMAL(10, 2),
+          allowNull: false,
+          defaultValue: 0
+        },
+        stock: {
+          type: Sequelize.INTEGER,
+          allowNull: false,
+          defaultValue: 0
+        },
+        estado: {
+          type: Sequelize.STRING(50),
+          allowNull: false,
+          defaultValue: 'Activo'
+        },
+        imagen: {
+          type: Sequelize.STRING(255),
+          allowNull: true
+        },
+        createdAt: {
+          allowNull: false,
+          type: Sequelize.DATE,
+          defaultValue: Sequelize.literal('CURRENT_TIMESTAMP')
+        },
+        updatedAt: {
+          allowNull: false,
+          type: Sequelize.DATE,
+          defaultValue: Sequelize.literal('CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP')
+        }
+      }, { transaction });
+
+      const cols = await queryInterface.describeTable('Clientes').catch(() => null);
+      if (cols && cols.price && cols.cantidad) {
+        await queryInterface.sequelize.query(
+          `INSERT INTO Productos (nombre, descripcion, categoria, precio, stock, estado, imagen, createdAt, updatedAt)
+           SELECT
+             nombre,
+             CASE
+               WHEN direccion IS NOT NULL AND direccion <> '' THEN direccion
+               WHEN apellido IS NOT NULL AND apellido <> '' THEN apellido
+               ELSE 'Sin descripción'
+             END AS descripcion,
+             CASE
+               WHEN apellido IS NOT NULL AND apellido <> '' THEN apellido
+               ELSE 'General'
+             END AS categoria,
+             price,
+             cantidad,
+             COALESCE(estado, 'Activo') AS estado,
+             imagen,
+             createdAt,
+             updatedAt
+           FROM Clientes
+           WHERE price IS NOT NULL OR cantidad IS NOT NULL OR imagen IS NOT NULL`,
+          { transaction }
+        );
+      }
+
+      await transaction.commit();
+    } catch (error) {
+      await transaction.rollback();
+      throw error;
+    }
+  },
+
+  async down(queryInterface) {
+    await queryInterface.dropTable('Productos');
+  }
+};

--- a/migrations/20250917031000-remove-product-fields-from-clientes.js
+++ b/migrations/20250917031000-remove-product-fields-from-clientes.js
@@ -1,0 +1,68 @@
+'use strict';
+
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    const transaction = await queryInterface.sequelize.transaction();
+    try {
+      const cols = await queryInterface.describeTable('Clientes').catch(() => ({}));
+
+      if (cols?.imagen) {
+        await queryInterface.removeColumn('Clientes', 'imagen', { transaction });
+      }
+      if (cols?.estado) {
+        await queryInterface.removeColumn('Clientes', 'estado', { transaction });
+      }
+      if (cols?.cantidad) {
+        await queryInterface.removeColumn('Clientes', 'cantidad', { transaction });
+      }
+      if (cols?.price) {
+        await queryInterface.removeColumn('Clientes', 'price', { transaction });
+      }
+
+      await transaction.commit();
+    } catch (error) {
+      await transaction.rollback();
+      throw error;
+    }
+  },
+
+  async down(queryInterface, Sequelize) {
+    const transaction = await queryInterface.sequelize.transaction();
+    try {
+      const cols = await queryInterface.describeTable('Clientes').catch(() => ({}));
+
+      if (!cols?.price) {
+        await queryInterface.addColumn('Clientes', 'price', {
+          type: Sequelize.DECIMAL(10, 2),
+          allowNull: false,
+          defaultValue: 0
+        }, { transaction });
+      }
+      if (!cols?.cantidad) {
+        await queryInterface.addColumn('Clientes', 'cantidad', {
+          type: Sequelize.INTEGER,
+          allowNull: false,
+          defaultValue: 0
+        }, { transaction });
+      }
+      if (!cols?.estado) {
+        await queryInterface.addColumn('Clientes', 'estado', {
+          type: Sequelize.STRING(50),
+          allowNull: false,
+          defaultValue: 'Activo'
+        }, { transaction });
+      }
+      if (!cols?.imagen) {
+        await queryInterface.addColumn('Clientes', 'imagen', {
+          type: Sequelize.STRING(255),
+          allowNull: true
+        }, { transaction });
+      }
+
+      await transaction.commit();
+    } catch (error) {
+      await transaction.rollback();
+      throw error;
+    }
+  }
+};

--- a/models/producto.js
+++ b/models/producto.js
@@ -1,0 +1,20 @@
+'use strict';
+
+module.exports = (sequelize, DataTypes) => {
+  const Producto = sequelize.define('Producto', {
+    id: { type: DataTypes.INTEGER, primaryKey: true, autoIncrement: true },
+    nombre: { type: DataTypes.STRING(150), allowNull: false },
+    descripcion: { type: DataTypes.TEXT, allowNull: false },
+    categoria: { type: DataTypes.STRING(120), allowNull: false, defaultValue: 'General' },
+    precio: { type: DataTypes.DECIMAL(10, 2), allowNull: false, defaultValue: 0 },
+    stock: { type: DataTypes.INTEGER, allowNull: false, defaultValue: 0 },
+    estado: { type: DataTypes.STRING(50), allowNull: false, defaultValue: 'Activo' },
+    imagen: { type: DataTypes.STRING(255), allowNull: true }
+  }, {
+    tableName: 'Productos',
+    timestamps: true
+  });
+
+  Producto.associate = function (_models) { /* relaciones futuras */ };
+  return Producto;
+};

--- a/repositories/clienteRepository.js
+++ b/repositories/clienteRepository.js
@@ -11,16 +11,10 @@ function toPOJO(row) {
     email,
     telefono,
     direccion,
-    price,
-    cantidad,
-    estado,
-    imagen,
     createdAt,
     updatedAt
-  } =
-    row.toJSON ? row.toJSON() : row;
-  const priceNumber = price != null ? Number(price) : null;
-  const cantidadNumber = cantidad != null ? Number(cantidad) : null;
+  } = row.toJSON ? row.toJSON() : row;
+
   return {
     id,
     nombre,
@@ -28,10 +22,6 @@ function toPOJO(row) {
     email,
     telefono,
     direccion,
-    price: priceNumber,
-    cantidad: cantidadNumber,
-    estado,
-    imagen,
     createdAt,
     updatedAt
   };
@@ -43,9 +33,9 @@ module.exports = {
     const where = q
       ? {
           [Op.or]: [
-            { nombre:   { [Op.like]: `%${q}%` } },
+            { nombre: { [Op.like]: `%${q}%` } },
             { apellido: { [Op.like]: `%${q}%` } },
-            { email:    { [Op.like]: `%${q}%` } }
+            { email: { [Op.like]: `%${q}%` } }
           ]
         }
       : {};
@@ -58,9 +48,9 @@ module.exports = {
     const where = q
       ? {
           [Op.or]: [
-            { nombre:   { [Op.like]: `%${q}%` } },
+            { nombre: { [Op.like]: `%${q}%` } },
             { apellido: { [Op.like]: `%${q}%` } },
-            { email:    { [Op.like]: `%${q}%` } }
+            { email: { [Op.like]: `%${q}%` } }
           ]
         }
       : {};

--- a/repositories/productoRepository.js
+++ b/repositories/productoRepository.js
@@ -1,0 +1,89 @@
+const { Op } = require('sequelize');
+const { Producto } = require('../models');
+
+function toPOJO(row) {
+  if (!row) return null;
+  const {
+    id,
+    nombre,
+    descripcion,
+    categoria,
+    precio,
+    stock,
+    estado,
+    imagen,
+    createdAt,
+    updatedAt
+  } = row.toJSON ? row.toJSON() : row;
+
+  const precioNumber = precio != null ? Number(precio) : null;
+  const stockNumber = stock != null ? Number(stock) : null;
+
+  return {
+    id,
+    nombre,
+    descripcion,
+    categoria,
+    precio: precioNumber,
+    stock: stockNumber,
+    estado,
+    imagen: imagen ?? null,
+    createdAt,
+    updatedAt
+  };
+}
+
+module.exports = {
+  async listar({ q = null, limit = 50, offset = 0, order = [['createdAt', 'DESC']] } = {}, tx) {
+    const where = q
+      ? {
+          [Op.or]: [
+            { nombre: { [Op.like]: `%${q}%` } },
+            { categoria: { [Op.like]: `%${q}%` } },
+            { descripcion: { [Op.like]: `%${q}%` } }
+          ]
+        }
+      : {};
+
+    const rows = await Producto.findAll({ where, limit, offset, order, transaction: tx });
+    return rows.map(toPOJO);
+  },
+
+  async listarPaginado({ q = null, page = 1, pageSize = 20, order = [['createdAt', 'DESC']] } = {}, tx) {
+    const where = q
+      ? {
+          [Op.or]: [
+            { nombre: { [Op.like]: `%${q}%` } },
+            { categoria: { [Op.like]: `%${q}%` } },
+            { descripcion: { [Op.like]: `%${q}%` } }
+          ]
+        }
+      : {};
+
+    const limit = pageSize;
+    const offset = (page - 1) * pageSize;
+    const { rows, count } = await Producto.findAndCountAll({ where, limit, offset, order, transaction: tx });
+    return { items: rows.map(toPOJO), total: count, page, pageSize };
+  },
+
+  async buscarPorId(id, tx) {
+    const row = await Producto.findByPk(id, { transaction: tx });
+    return toPOJO(row);
+  },
+
+  async crear(data, tx) {
+    const row = await Producto.create(data, { transaction: tx });
+    return toPOJO(row);
+  },
+
+  async actualizar(id, data, tx) {
+    await Producto.update(data, { where: { id }, transaction: tx });
+    const row = await Producto.findByPk(id, { transaction: tx });
+    return toPOJO(row);
+  },
+
+  async eliminar(id, tx) {
+    const n = await Producto.destroy({ where: { id }, transaction: tx });
+    return n > 0;
+  }
+};

--- a/routes/cliente.routes.js
+++ b/routes/cliente.routes.js
@@ -2,7 +2,6 @@ const express = require('express');
 const adapter = require('../adapters/clienteAdapter');
 const validate = require('../middleware/validate');
 const { requiereAuth, requiereAdmin } = require('../middleware/authJwt');
-const { handleSingle } = require('../middleware/uploadProductImage');
 const {
   crearClienteRules,
   actualizarClienteRules,
@@ -19,7 +18,6 @@ r.post(
   '/',
   requiereAuth,
   requiereAdmin,
-  handleSingle('imagen'),
   crearClienteRules,
   validate,
   adapter.crear
@@ -30,7 +28,6 @@ r.put(
   '/:id',
   requiereAuth,
   requiereAdmin,
-  handleSingle('imagen'),
   actualizarClienteRules,
   validate,
   adapter.actualizar

--- a/routes/producto.routes.js
+++ b/routes/producto.routes.js
@@ -1,13 +1,13 @@
 const express = require('express');
-const adapter = require('../adapters/clienteAdapter');
+const adapter = require('../adapters/productoAdapter');
 const validate = require('../middleware/validate');
 const { requiereAuth, requiereAdmin } = require('../middleware/authJwt');
 const { handleSingle } = require('../middleware/uploadProductImage');
 const {
-  crearClienteRules,
-  actualizarClienteRules,
-  eliminarClienteRules,
-} = require('../middleware/validaciones/cliente');
+  crearProductoRules,
+  actualizarProductoRules,
+  eliminarProductoRules,
+} = require('../middleware/validaciones/producto');
 
 const r = express.Router();
 
@@ -18,7 +18,7 @@ r.post(
   requiereAuth,
   requiereAdmin,
   handleSingle('imagen'),
-  crearClienteRules,
+  crearProductoRules,
   validate,
   adapter.crear,
 );
@@ -28,7 +28,7 @@ r.put(
   requiereAuth,
   requiereAdmin,
   handleSingle('imagen'),
-  actualizarClienteRules,
+  actualizarProductoRules,
   validate,
   adapter.actualizar,
 );
@@ -37,7 +37,7 @@ r.delete(
   '/:id',
   requiereAuth,
   requiereAdmin,
-  eliminarClienteRules,
+  eliminarProductoRules,
   validate,
   adapter.eliminar,
 );


### PR DESCRIPTION
## Resumen
- crear la tabla `Productos` con migración de datos desde columnas heredadas de clientes y limpiar luego los campos de producto en `Clientes`
- añadir el modelo/repositorio/controlador/adaptador/validaciones específicos para productos y actualizar las rutas para usarlos
- restaurar el controlador, repositorio y validaciones de clientes a su responsabilidad original de datos de clientes

## Testing
- no se ejecutaron pruebas automatizadas (no disponibles)


------
https://chatgpt.com/codex/tasks/task_e_68d3231646e8832f97417b818f4be2ab